### PR TITLE
Bring xml sample in line with yaml/neon

### DIFF
--- a/docs/examples/basic.dto.xml
+++ b/docs/examples/basic.dto.xml
@@ -15,7 +15,7 @@
 	</dto>
 
 	<dto name="Cars">
-		<field name="cars" type="Car[]" collection="true" />
+		<field name="cars" type="Car[]" collection="true" associative="true" />
 	</dto>
 
 	<dto name="Owner">

--- a/tests/TestCase/Dto/DtoTest.php
+++ b/tests/TestCase/Dto/DtoTest.php
@@ -196,26 +196,33 @@ class DtoTest extends TestCase {
 	 */
 	public function testToArrayCollection() {
 		$carsDto = new CarsDto();
-		$carsDto->addCar(new CarDto(['distanceTravelled' => 123]));
-		$carsDto->addCar(new CarDto(['distanceTravelled' => 234]));
-		$carsDto->addCar(new CarDto(['distanceTravelled' => 345]));
+		$carOne = new CarDto(['distanceTravelled' => 123]);
+		$carTwo = new CarDto(['distanceTravelled' => 234]);
+		$carThree = new CarDto(['distanceTravelled' => 345]);
+
+		$carsDto->addCar('one', $carOne);
+		$carsDto->addCar('two', $carTwo);
+		$carsDto->addCar('three', $carThree);
 
 		$result = $carsDto->touchedToArray();
 
 		$expected = [
 			'cars' => [
-				[
+				'one' => [
 					'distanceTravelled' => 123
 				],
-				[
+				'two' => [
 					'distanceTravelled' => 234
 				],
-				[
+				'three' => [
 					'distanceTravelled' => 345
 				]
 			]
 		];
 		$this->assertSame($expected, $result);
+		$this->assertSame($carOne, $carsDto->getCar('one'));
+		$this->assertSame($carTwo, $carsDto->getCar('two'));
+		$this->assertSame($carThree, $carsDto->getCar('three'));
 	}
 
 	/**
@@ -282,13 +289,13 @@ class DtoTest extends TestCase {
 	 */
 	public function testSerializeCollection() {
 		$carsDto = new CarsDto();
-		$carsDto->addCar(new CarDto(['distanceTravelled' => 123]));
-		$carsDto->addCar(new CarDto(['distanceTravelled' => 234]));
-		$carsDto->addCar(new CarDto(['distanceTravelled' => 345]));
+		$carsDto->addCar('one', new CarDto(['distanceTravelled' => 123]));
+		$carsDto->addCar('two', new CarDto(['distanceTravelled' => 234]));
+		$carsDto->addCar('three', new CarDto(['distanceTravelled' => 345]));
 
 		$result = $carsDto->serialize();
 
-		$expected = '{"cars":[{"distanceTravelled":123},{"distanceTravelled":234},{"distanceTravelled":345}]}';
+		$expected = '{"cars":{"one":{"distanceTravelled":123},"two":{"distanceTravelled":234},"three":{"distanceTravelled":345}}}';
 		$this->assertSame($expected, $result);
 
 		$carsDto->unserialize($expected);

--- a/tests/TestCase/Engine/XmlEngineTest.php
+++ b/tests/TestCase/Engine/XmlEngineTest.php
@@ -79,6 +79,7 @@ class XmlEngineTest extends TestCase {
 						'name' => 'cars',
 						'type' => 'Car[]',
 						'collection' => true,
+						'associative' => true
 					]
 				]
 			],

--- a/tests/test_app/src/Dto/CarsDto.php
+++ b/tests/test_app/src/Dto/CarsDto.php
@@ -27,13 +27,13 @@ class CarsDto extends \CakeDto\Dto\AbstractDto {
 		'cars' => [
 			'name' => 'cars',
 			'type' => 'CarDto[]|\ArrayObject',
+			'associative' => true,
 			'required' => false,
 			'defaultValue' => null,
 			'isDto' => false,
 			'class' => null,
 			'singularClass' => '\TestApp\Dto\CarDto',
 			'collectionType' => '\ArrayObject',
-			'associative' => false,
 			'serializable' => false,
 			'toArray' => false,
 		],
@@ -75,6 +75,21 @@ class CarsDto extends \CakeDto\Dto\AbstractDto {
 	}
 
 	/**
+	 * @param string $key
+	 *
+	 * @return CarDto
+	 *
+	 * @throws \RuntimeException If value with this key is not set.
+	 */
+	public function getCar($key) {
+		if (!isset($this->cars[$key])) {
+			throw new \RuntimeException(sprintf('Value not set for field `cars` and key `%s` (expected to be not null)', $key));
+		}
+
+		return $this->cars[$key];
+	}
+
+	/**
 	 * @return bool
 	 */
 	public function hasCars() {
@@ -84,16 +99,26 @@ class CarsDto extends \CakeDto\Dto\AbstractDto {
 
 		return $this->cars->count() > 0;
 	}
+
 	/**
+	 * @param string $key
+	 * @return bool
+	 */
+	public function hasCar($key) {
+		return isset($this->cars[$key]);
+	}
+
+	/**
+	 * @param string $key
 	 * @param CarDto $car
 	 * @return $this
 	 */
-	public function addCar(CarDto $car) {
+	public function addCar($key, CarDto $car) {
 		if (!isset($this->cars)) {
 			$this->cars = new \ArrayObject([]);
 		}
 
-		$this->cars[] = $car;
+		$this->cars[$key] = $car;
 		$this->_touchedFields[self::FIELD_CARS] = true;
 
 		return $this;


### PR DESCRIPTION
This PR brings back on par with yaml/neon the following xml sample: `./docs/examples/basic.dto.xml` 