### PR TITLE
Namespace of plugin class is invalid?

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ composer require dereuromark/cakephp-dto:dev-master
 
 Then load the plugin with the following command:
 ```
-bin/cake plugin load dereuromark/cakephp-dto -b
+bin/cake plugin load CakeDto -b
 ```
 The bootstrap is needed for the TwigView events to be set up. If you already included TwigView, you might not need the bootstrap.
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dto;
+namespace CakeDto;
 
 use Cake\Core\BasePlugin;
 


### PR DESCRIPTION
First of all, thanks to this plugin and i'm excited about the great idea!

I cloned this and try following README, but CLI command is not working.
(with CakePHP 3.6.14 on PHP 7.2.6 (cli))

```
$ bin/cake plugin load dereuromark/cakephp-dto -b
app/src/Application.php modified
$ bin/cake dto
PHP Fatal error:  Uncaught Cake\Core\Exception\MissingPluginException: Plugin dereuromark/cakephp-dto could not be found.
```

In composer.json, autoload config is set with `CakeDto`, while `src/Plugin`'s namespace is `DTO`.
After fix the plugin namespace to `CakeDto` as composer.json, I can work with this.

```
$ bin/cake plugin load CakeDto -b

app/src/Application.php modified
$ bin/cake dto
No subcommand provided. Choose one of the available subcommands.

Usage:
cake dto [subcommand] [-h] [-q] [-v]

Subcommands:

generate  Generate DTOs from current config.
init      Create a new file to start from in your /config dir.

To see help on a subcommand use `cake dto [subcommand] --help`

Options:

--help, -h     Display this help.
--quiet, -q    Enable quiet output.
--verbose, -v  Enable verbose output.
```

Thanks again 😄 