### PR TITLE
Fix deprecated errors in tests for 3.7 release.

### DIFF
--- a/tests/TestCase/Engine/XmlValidatorTest.php
+++ b/tests/TestCase/Engine/XmlValidatorTest.php
@@ -19,6 +19,7 @@ class XmlValidatorTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
+		$this->loadPlugins(['CakeDto']);
 		$this->validator = XmlValidator::class;
 	}
 

--- a/tests/TestCase/Generator/BuilderTest.php
+++ b/tests/TestCase/Generator/BuilderTest.php
@@ -26,6 +26,7 @@ class BuilderTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
+		$this->loadPlugins(['CakeDto']);
 		Configure::write('CakeDto.scalarTypeHints', false);
 
 		$engine = new XmlEngine();

--- a/tests/TestCase/Generator/GeneratorTest.php
+++ b/tests/TestCase/Generator/GeneratorTest.php
@@ -52,6 +52,8 @@ class GeneratorTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
+		$this->loadPlugins(['CakeDto']);
+
 		// Why needed?
 		EventManager::instance()->on(new ExtensionsListener());
 		EventManager::instance()->on(new TokenParsersListener());

--- a/tests/TestCase/Shell/DtoShellTest.php
+++ b/tests/TestCase/Shell/DtoShellTest.php
@@ -31,6 +31,8 @@ class DtoShellTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
+		$this->loadPlugins(['CakeDto']);
+
 		$this->out = new ConsoleOutput();
 		$this->err = new ConsoleOutput();
 		$io = new ConsoleIo($this->out, $this->err);

--- a/tests/TestCase/View/DtoViewTest.php
+++ b/tests/TestCase/View/DtoViewTest.php
@@ -3,7 +3,6 @@ namespace CakeDto\Test\TestCase\View;
 
 use CakeDto\View\DtoView;
 use Cake\Core\Configure;
-use Cake\Core\Plugin;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest as Request;
 use Cake\TestSuite\StringCompareTrait;
@@ -31,7 +30,7 @@ class DtoViewTest extends TestCase {
 
 		Configure::write(
 			'App.paths.templates.x',
-			Plugin::path('CakeDto') . 'tests' . DS . 'test_app' . DS . 'src' . DS . 'Template' . DS . 'Twig' . DS
+			TEST_APP . DS . 'Template' . DS . 'Twig' . DS
 		);
 	}
 

--- a/tests/TestCase/View/RendererTest.php
+++ b/tests/TestCase/View/RendererTest.php
@@ -4,7 +4,6 @@ namespace CakeDto\Test\TestCase\View;
 
 use CakeDto\View\Renderer;
 use Cake\Core\Configure;
-use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
 
 class RendererTest extends TestCase {
@@ -24,7 +23,7 @@ class RendererTest extends TestCase {
 
 		Configure::write(
 			'App.paths.templates.x',
-			Plugin::path('CakeDto') . 'tests' . DS . 'test_app' . DS . 'src' . DS . 'Template' . DS . 'Renderer' . DS
+			TEST_APP . DS . 'Template' . DS . 'Renderer' . DS
 		);
 		Configure::delete('CakeDto.strictTypes');
 	}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,6 +5,7 @@ if (!defined('DS')) {
 }
 define('ROOT', dirname(__DIR__));
 define('APP_DIR', 'src');
+define('TEST_APP', ROOT . DS . 'tests' . DS . 'test_app' . DS . 'src');
 
 define('APP', rtrim(sys_get_temp_dir(), DS) . DS . APP_DIR . DS);
 if (!is_dir(APP)) {
@@ -43,5 +44,4 @@ Cake\Core\Configure::write('CakeDto', [
 
 Cake\Core\Configure::write('debug', true);
 
-Cake\Core\Plugin::load('CakeDto', ['path' => ROOT . DS, 'autoload' => true, 'bootstrap' => true]);
 //Cake\Core\Plugin::load('WyriHaximus/TwigView', ['path' => ROOT . DS . 'vendor/wyrihaximus/twig-view/', 'autoload' => true, 'bootstrap' => true]);


### PR DESCRIPTION
`Plugin::load()` is deprecated. We can use `TestCase::loadPlugins();` instead.