### PR TITLE
3.7 deprecated warnings

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -25,6 +25,7 @@ define('CORE_PATH', CAKE_CORE_INCLUDE_PATH . DS);
 define('CAKE', CORE_PATH . APP_DIR . DS);
 
 require dirname(__DIR__) . '/vendor/autoload.php';
+require CONFIG . 'bootstrap.php';
 require CORE_PATH . 'config/bootstrap.php';
 
 Cake\Core\Configure::write('App', [

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -25,8 +25,8 @@ define('CORE_PATH', CAKE_CORE_INCLUDE_PATH . DS);
 define('CAKE', CORE_PATH . APP_DIR . DS);
 
 require dirname(__DIR__) . '/vendor/autoload.php';
-require CONFIG . 'bootstrap.php';
 require CORE_PATH . 'config/bootstrap.php';
+require CONFIG . 'bootstrap.php';
 
 Cake\Core\Configure::write('App', [
 	'namespace' => 'App',

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -43,5 +43,5 @@ Cake\Core\Configure::write('CakeDto', [
 
 Cake\Core\Configure::write('debug', true);
 
-Cake\Core\Plugin::load('CakeDto', ['path' => ROOT . DS, 'autoload' => true, 'bootstrap' => true]);
+Cake\Core\Plugin::getCollection()->add(new CakeDto\Plugin());
 //Cake\Core\Plugin::load('WyriHaximus/TwigView', ['path' => ROOT . DS . 'vendor/wyrihaximus/twig-view/', 'autoload' => true, 'bootstrap' => true]);


### PR DESCRIPTION
`Plugin::load()` is marked as deprecated in 3.7, use `Plugin::getCollection()->add()` instead.