### PR TITLE
Add get set access via property.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -387,6 +387,20 @@ will transform into the DTO field as associative array collection:
 These methods should be used carefully, for security reasons.
 Make sure none of the values are dangerous objects. Best to use only for scalar values.
 
+### Property access
+In some cases it can be easier to use `->get('myField')` or `->myField` access.
+Especially with a programmatic access to the DTO you will find this easier than manually inflecting.
+```php
+$field = 'myField';
+$value = $dto->$field;
+```
+The advantage of the property access here is to retain full return-type-hinting.
+
+In case you only have the underscored or dashed version, you need to call `field()` first.
+```php
+$field = $dto->field('my_field'); // returns 'myField'
+$dto->set($field, $value);
+```
 
 ### PHP Template Usage
 Inside templates just annotate the variables passed down in the doc block at the top:

--- a/src/Dto/Dto.php
+++ b/src/Dto/Dto.php
@@ -579,6 +579,10 @@ abstract class Dto implements Serializable {
 			$field = $this->field($field, $type);
 		}
 
+		if (!isset($this->_metadata[$field])) {
+			throw new RuntimeException('Field does not exist: ' . $field);
+		}
+
 		$method = 'has' . ucfirst($field);
 
 		return $this->$method();
@@ -593,6 +597,10 @@ abstract class Dto implements Serializable {
 	public function &get($field, $type = self::TYPE_DEFAULT) {
 		if ($type !== static::TYPE_DEFAULT) {
 			$field = $this->field($field, $type);
+		}
+
+		if (!isset($this->_metadata[$field])) {
+			throw new RuntimeException('Field does not exist: ' . $field);
 		}
 
 		$method = 'get' . ucfirst($field);
@@ -612,6 +620,10 @@ abstract class Dto implements Serializable {
 	public function set($field, $value, $type = self::TYPE_DEFAULT) {
 		if ($type !== static::TYPE_DEFAULT) {
 			$field = $this->field($field, $type);
+		}
+
+		if (!isset($this->_metadata[$field])) {
+			throw new RuntimeException('Field does not exist: ' . $field);
 		}
 
 		$method = 'set' . ucfirst($field);

--- a/src/Template/Dto/Element/doc.twig
+++ b/src/Template/Dto/Element/doc.twig
@@ -1,0 +1,4 @@
+ *
+{% for field in fields %}
+ * @property {{ field.type }}{% if field.nullable %}|null{% endif %} ${{ field.name }}
+{% endfor %}

--- a/src/Template/Dto/dto.twig
+++ b/src/Template/Dto/dto.twig
@@ -9,6 +9,7 @@ namespace {{ namespace }};
 
 /**
  * {{ name }} DTO
+{% element 'doc' fields %}
  {% if deprecated is not null -%}
  *
  * @deprecated {{ deprecated }}

--- a/tests/TestCase/Dto/DtoTest.php
+++ b/tests/TestCase/Dto/DtoTest.php
@@ -5,7 +5,6 @@ namespace CakeDto\Test\TestCase\Dto;
 use ArrayObject;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
-use RuntimeException;
 use TestApp\Dto\CarDto;
 use TestApp\Dto\CarsDto;
 use TestApp\Dto\FlyingCarDto;
@@ -334,15 +333,15 @@ class DtoTest extends TestCase {
 	public function testArrayAccess() {
 		$dto = new CarDto();
 
-		$this->assertTrue(isset($dto['distanceTravelled']));
-		$this->assertTrue(empty($dto['distanceTravelled']));
+		$this->assertTrue(isset($dto->distanceTravelled));
+		$this->assertTrue(empty($dto->distanceTravelled));
 
 		$dto->setDistanceTravelled(111);
 
-		$this->assertTrue(isset($dto['distanceTravelled']));
-		$this->assertTrue(!empty($dto['distanceTravelled']));
+		$this->assertTrue(isset($dto->distanceTravelled));
+		$this->assertTrue(!empty($dto->distanceTravelled));
 
-		$result = $dto['distanceTravelled'];
+		$result = $dto->distanceTravelled;
 		$this->assertSame(111, $result);
 	}
 
@@ -350,11 +349,6 @@ class DtoTest extends TestCase {
 	 * @return void
 	 */
 	public function testArrayAccessInvalidWrite() {
-		$dto = new CarDto();
-
-		$this->expectException(RuntimeException::class);
-
-		$dto['distanceTravelled'] = 111;
 	}
 
 	/**

--- a/tests/TestCase/Dto/DtoTest.php
+++ b/tests/TestCase/Dto/DtoTest.php
@@ -327,8 +327,19 @@ class DtoTest extends TestCase {
 	}
 
 	/**
-	 * isset() apparently is also true for empty (null value).
-	 *
+	 * @return void
+	 */
+	public function testField() {
+		$carDto = new CarDto();
+
+		$field = $carDto->field('distance_travelled', $carDto::TYPE_UNDERSCORED);
+		$this->assertSame('distanceTravelled', $field);
+
+		$field = $carDto->field('distance-travelled', $carDto::TYPE_DASHED);
+		$this->assertSame('distanceTravelled', $field);
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testPropertyAccess() {

--- a/tests/TestCase/Dto/DtoTest.php
+++ b/tests/TestCase/Dto/DtoTest.php
@@ -5,6 +5,7 @@ namespace CakeDto\Test\TestCase\Dto;
 use ArrayObject;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use RuntimeException;
 use TestApp\Dto\CarDto;
 use TestApp\Dto\CarsDto;
 use TestApp\Dto\FlyingCarDto;
@@ -333,6 +334,8 @@ class DtoTest extends TestCase {
 	public function testPropertyAccess() {
 		$carDto = new CarDto();
 
+		$this->assertNull($carDto->distanceTravelled);
+
 		$this->assertFalse(isset($carDto->distanceTravelled));
 		$this->assertFalse(!empty($carDto->distanceTravelled));
 
@@ -355,6 +358,17 @@ class DtoTest extends TestCase {
 
 		$result = $carDto->distanceTravelled;
 		$this->assertSame(111, $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testPropertyAccessWriteInvalid() {
+		$carDto = new CarDto();
+
+		$this->expectException(RuntimeException::class);
+
+		$carDto->distance_travelled = 111;
 	}
 
 	/**

--- a/tests/TestCase/Dto/DtoTest.php
+++ b/tests/TestCase/Dto/DtoTest.php
@@ -319,9 +319,9 @@ class DtoTest extends TestCase {
 	 * @return void
 	 */
 	public function testDebugInfo() {
-		$dto = new CarDto();
+		$carDto = new CarDto();
 
-		$result = $dto->__debugInfo();
+		$result = $carDto->__debugInfo();
 		$this->assertSame(['data', 'touched', 'extends', 'immutable'], array_keys($result));
 	}
 
@@ -330,25 +330,31 @@ class DtoTest extends TestCase {
 	 *
 	 * @return void
 	 */
-	public function testArrayAccess() {
-		$dto = new CarDto();
+	public function testPropertyAccess() {
+		$carDto = new CarDto();
 
-		$this->assertTrue(isset($dto->distanceTravelled));
-		$this->assertTrue(empty($dto->distanceTravelled));
+		$this->assertFalse(isset($carDto->distanceTravelled));
+		$this->assertFalse(!empty($carDto->distanceTravelled));
 
-		$dto->setDistanceTravelled(111);
+		$carDto->setDistanceTravelled(111);
 
-		$this->assertTrue(isset($dto->distanceTravelled));
-		$this->assertTrue(!empty($dto->distanceTravelled));
+		$this->assertTrue(isset($carDto->distanceTravelled));
+		$this->assertTrue(!empty($carDto->distanceTravelled));
 
-		$result = $dto->distanceTravelled;
+		$result = $carDto->distanceTravelled;
 		$this->assertSame(111, $result);
 	}
 
 	/**
 	 * @return void
 	 */
-	public function testArrayAccessInvalidWrite() {
+	public function testPropertyAccessWrite() {
+		$carDto = new CarDto();
+
+		$carDto->distanceTravelled = 111;
+
+		$result = $carDto->distanceTravelled;
+		$this->assertSame(111, $result);
 	}
 
 	/**

--- a/tests/TestCase/Generator/GeneratorTest.php
+++ b/tests/TestCase/Generator/GeneratorTest.php
@@ -174,6 +174,10 @@ namespace App\Dto\MyForest;
 
 /**
  * MyForest/MySpecialTree DTO
+TXT;
+		$this->assertTextContains($expected, $content);
+
+		$expected = <<<TXT
  */
 class MySpecialTreeDto extends \App\Dto\MyForest\MyTreeDto {
 TXT;

--- a/tests/files/AnimalDto/dto.txt
+++ b/tests/files/AnimalDto/dto.txt
@@ -1,5 +1,3 @@
-/**
- * Animal DTO
  *
  * @deprecated Deprecated now
  */

--- a/tests/test_app/src/Dto/ArticleDto.php
+++ b/tests/test_app/src/Dto/ArticleDto.php
@@ -8,6 +8,13 @@ namespace TestApp\Dto;
 
 /**
  * Article DTO
+ *
+ * @property int $id
+ * @property \TestApp\Dto\AuthorDto $author
+ * @property string $title
+ * @property \Cake\I18n\FrozenDate $created
+ * @property \TestApp\Dto\TagDto[] $tags
+ * @property string[] $meta
  */
 class ArticleDto extends \CakeDto\Dto\AbstractImmutableDto {
 

--- a/tests/test_app/src/Dto/AuthorDto.php
+++ b/tests/test_app/src/Dto/AuthorDto.php
@@ -8,6 +8,10 @@ namespace TestApp\Dto;
 
 /**
  * Author DTO
+ *
+ * @property int $id
+ * @property string $name
+ * @property string|null $email
  */
 class AuthorDto extends \CakeDto\Dto\AbstractImmutableDto {
 

--- a/tests/test_app/src/Dto/BookDto.php
+++ b/tests/test_app/src/Dto/BookDto.php
@@ -8,6 +8,8 @@ namespace TestApp\Dto;
 
 /**
  * Book DTO
+ *
+ * @property \TestApp\Dto\PageDto[]|\Cake\Collection\Collection $pages
  */
 class BookDto extends \CakeDto\Dto\AbstractImmutableDto {
 

--- a/tests/test_app/src/Dto/CarDto.php
+++ b/tests/test_app/src/Dto/CarDto.php
@@ -8,6 +8,14 @@ namespace TestApp\Dto;
 
 /**
  * Car DTO
+ *
+ * @property \TestApp\ValueObject\Paint|null $color
+ * @property bool|null $isNew
+ * @property float|null $value
+ * @property int|null $distanceTravelled
+ * @property string[]|null $attributes
+ * @property \Cake\I18n\FrozenDate|null $manufactured
+ * @property \TestApp\Dto\OwnerDto|null $owner
  */
 class CarDto extends \CakeDto\Dto\AbstractDto {
 

--- a/tests/test_app/src/Dto/CarsDto.php
+++ b/tests/test_app/src/Dto/CarsDto.php
@@ -8,6 +8,8 @@ namespace TestApp\Dto;
 
 /**
  * Cars DTO
+ *
+ * @property \TestApp\Dto\CarDto[]|\ArrayObject $cars
  */
 class CarsDto extends \CakeDto\Dto\AbstractDto {
 

--- a/tests/test_app/src/Dto/CustomerAccountDto.php
+++ b/tests/test_app/src/Dto/CustomerAccountDto.php
@@ -8,6 +8,9 @@ namespace TestApp\Dto;
 
 /**
  * CustomerAccount DTO
+ *
+ * @property string $customerName
+ * @property int|null $birthYear
  */
 class CustomerAccountDto extends \CakeDto\Dto\AbstractDto {
 

--- a/tests/test_app/src/Dto/EmptyOneDto.php
+++ b/tests/test_app/src/Dto/EmptyOneDto.php
@@ -8,6 +8,7 @@ namespace TestApp\Dto;
 
 /**
  * EmptyOne DTO
+ *
  */
 class EmptyOneDto extends \CakeDto\Dto\AbstractDto {
 

--- a/tests/test_app/src/Dto/FlyingCarDto.php
+++ b/tests/test_app/src/Dto/FlyingCarDto.php
@@ -8,6 +8,10 @@ namespace TestApp\Dto;
 
 /**
  * FlyingCar DTO
+ *
+ * @property int $maxAltitude
+ * @property int $maxSpeed
+ * @property array|null $complexAttributes
  */
 class FlyingCarDto extends CarDto {
 

--- a/tests/test_app/src/Dto/MutableMetaDto.php
+++ b/tests/test_app/src/Dto/MutableMetaDto.php
@@ -8,6 +8,9 @@ namespace TestApp\Dto;
 
 /**
  * MutableMeta DTO
+ *
+ * @property string $title
+ * @property string[] $meta
  */
 class MutableMetaDto extends \CakeDto\Dto\AbstractDto {
 

--- a/tests/test_app/src/Dto/OldOneDto.php
+++ b/tests/test_app/src/Dto/OldOneDto.php
@@ -9,6 +9,8 @@ namespace TestApp\Dto;
 /**
  * OldOne DTO
  *
+ * @property string|null $name
+ *
  * @deprecated Yeah, sry
  */
 class OldOneDto extends CarDto {

--- a/tests/test_app/src/Dto/OwnerDto.php
+++ b/tests/test_app/src/Dto/OwnerDto.php
@@ -8,6 +8,9 @@ namespace TestApp\Dto;
 
 /**
  * Owner DTO
+ *
+ * @property string|null $name
+ * @property int|null $birthYear
  */
 class OwnerDto extends \CakeDto\Dto\AbstractDto {
 

--- a/tests/test_app/src/Dto/PageDto.php
+++ b/tests/test_app/src/Dto/PageDto.php
@@ -8,6 +8,9 @@ namespace TestApp\Dto;
 
 /**
  * Page DTO
+ *
+ * @property int $number
+ * @property string|null $content
  */
 class PageDto extends \CakeDto\Dto\AbstractImmutableDto {
 

--- a/tests/test_app/src/Dto/TagDto.php
+++ b/tests/test_app/src/Dto/TagDto.php
@@ -8,6 +8,10 @@ namespace TestApp\Dto;
 
 /**
  * Tag DTO
+ *
+ * @property int $id
+ * @property string $name
+ * @property int $weight
  */
 class TagDto extends \CakeDto\Dto\AbstractImmutableDto {
 

--- a/tests/test_app/src/Dto/TransactionDto.php
+++ b/tests/test_app/src/Dto/TransactionDto.php
@@ -8,6 +8,11 @@ namespace TestApp\Dto;
 
 /**
  * Transaction DTO
+ *
+ * @property \TestApp\Dto\CustomerAccountDto $customerAccount
+ * @property float $value
+ * @property string|null $comment
+ * @property \Cake\I18n\FrozenDate $created
  */
 class TransactionDto extends \CakeDto\Dto\AbstractImmutableDto {
 


### PR DESCRIPTION
- Resolves https://github.com/dereuromark/cakephp-dto/issues/8
- Removes bad array access

open issues before merging
- Adding more tests
- check phpstan on the property overwrite (does it work, as the actual field is protected?), otherwise we need to use _ for properties internally to avoid this issue.