### PR TITLE
Add read() access to be closer to CakePHP reading.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -220,6 +220,36 @@ Tools like PHPStan understand the important difference here and warn you if you 
 Using `has{Field}()` you can check on the existence of a value, basically `!== null` for fields.
 Collections, however, cannot be null, they always return something. This means that for those the method returns true for `count > 0`.
 
+### Read
+Using `read()` you can use a path array to quickly access deeply nested values.
+This is especially useful if any of the elements in the chain can be null. Usually you have to check for each level separately:
+```php
+// Nothing can be null in between, typehinted as int
+$green = $carsDto->getCarOrFail('one')->getColorOrFail()->getGreenOrFail();
+
+// Something can be null in between, typehinted as int|null
+$greenOrNull = null;
+if ($carDto->hasCar('one')) {
+    $carDto = $carsDto->getCar('one');
+    if ($carDto->hasColor()) {
+        $color = $carDto->getColor();
+        $greenOrNull = $color->getGreen();
+    }
+}
+
+// Typehinted as mixed|null
+$greenOrNull = $carsDto->read(['cars', 'one', 'color', 'green']);
+```
+ 
+The downside is that you lose the return type-hinting which is usually useful for static analysis.
+It should also be avoided where not needed - as you lose the auto-complete/type-hinting aspect.
+Using the class constants as field names can however compensite a bit:
+```php
+$path = [$carsDto::FIELD_CARS, 'one', CarDto::FIELD_COLOR, 'green'];
+$greenOrNull = $carsDto->read($path);
+```
+The associative key doesn't have a class constant, neither does the key of the value object.
+
 ### FromArray/ToArray
 These methods allow to transport data from array to DTO, the other way around or between DTOs.
 Using `touchedToArray()` you can also just shift over the fields that have been set.

--- a/src/Dto/Dto.php
+++ b/src/Dto/Dto.php
@@ -2,6 +2,7 @@
 
 namespace CakeDto\Dto;
 
+use ArrayAccess;
 use CakeDto\View\Json;
 use Cake\Collection\Collection;
 use Countable;
@@ -81,6 +82,33 @@ abstract class Dto implements Serializable {
 
 		$this->setDefaults();
 		$this->validate();
+	}
+
+	/**
+	 * @param string $path
+	 * @param mixed|null $default The return value when the path does not exist
+	 * @return mixed|null The value fetched from the DTO, or null.
+	 */
+	public function read(array $path, $default = null) {
+		$data = null;
+		foreach ($path as $key) {
+			if ($data === null && !$this->has($key)) {
+				return $default;
+			}
+			if ($data === null) {
+				$data = $this->get($key);
+				continue;
+			}
+			if ($data instanceof self || $data instanceof FromArrayToArrayInterface) {
+				$data = $data->toArray();
+			}
+			if ((is_array($data) || $data instanceof ArrayAccess) && isset($data[$key])) {
+				$data = $data[$key];
+			} else {
+				return $default;
+			}
+		}
+		return $data;
 	}
 
 	/**

--- a/src/Dto/Dto.php
+++ b/src/Dto/Dto.php
@@ -85,8 +85,8 @@ abstract class Dto implements Serializable {
 	}
 
 	/**
-	 * @param string $path
-	 * @param mixed|null $default The return value when the path does not exist
+	 * @param string[] $path Path as array of strings.
+	 * @param mixed|null $default The return value when the path does not exist.
 	 * @return mixed|null The value fetched from the DTO, or null.
 	 */
 	public function read(array $path, $default = null) {


### PR DESCRIPTION
Implements https://github.com/dereuromark/cakephp-dto/issues/21
```php
$path = [$articleDto::FIELD_AUTHOR, AuthorDto::FIELD_NAME];
// or
$greenOrNull = $carsDto->read(['cars', 'one', 'color', 'green']);
```

I specifically didnt use the cake dot syntax as that would require more logic and parsing, having the array makes it super simple.
Big bonus:
If you use the exposed class constants, you have even the fields available to you as autocomplete and you will know on refactor what will not work anymore.

Brings this also closer to how entity read() works using [ReadTrait](https://github.com/dereuromark/cakephp-shim/blob/master/src/Model/Entity/ReadTrait.php).