### PR TITLE
Allow new major of sebastian/diff

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 		"php": ">=7.2",
 		"cakephp/cakephp": "^4.0",
 		"wyrihaximus/twig-view": "^5.0.1",
-		"sebastian/diff": "^3.0.2"
+		"sebastian/diff": "^3.0.2|^4.0.0"
 	},
 	"require-dev": {
 		"ext-dom": "*",


### PR DESCRIPTION
This can only be tested with PHPUnit 9 though.

also: sebastian/diff           4.0.0      requires  php ^7.3