### PR TITLE
Allow nullable for singular of collections.

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -3,8 +3,8 @@
 return [
 	'CakeDto' => [
 		'format' => 'xml', // or your custom yml, neon, ...
-		'strictTypes' => false, // Requires PHP 7.1+
-		'scalarTypeHints' => false, // null => Auto-detect, requires PHP 7.1+
+		'strictTypes' => false, // This can create casting requirement
+		'scalarTypeHints' => true,
 		'immutable' => false, // This can have a negative performance impact
 		'defaultCollectionType' => null, // Defaults to \ArrayObject
 		'debug' => false, // Add all meta data into DTOs for debugging

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,12 +57,12 @@ Let's add some basic DTOs now:
     <dto name="Cars">
         <field name="cars" type="Car[]" collection="true" singular="car" />
     </dto>
-    
+
     <dto name="Owner">
         <field name="name" type="string"/>
         <field name="birthYear" type="int"/>
     </dto>
-    
+
     <dto name="FlyingCar" extends="Car">
         <field name="maxAltitude" type="int"/>
     </dto>
@@ -113,13 +113,13 @@ Simple scalars and types:
 - `bool`
 - `callable`
 - `resource`
-- `iterable` (requires PHP 7.1+)
-- `object` (requires PHP 7.2+)
+- `iterable`
+- `object`
 - `mixed`
 
 Simple array types:
 - `array` without array typehinting, but no further annotation (assumes "mixed" type)
-- `...[]` with array typehinting and concrete annotation ("mixed is not allowed here)
+- `...[]` with array typehinting and concrete annotation ("mixed" is not allowed here)
 
 Concrete objects:
 - DTOs (without suffix)
@@ -162,16 +162,16 @@ Based on the type of field, it will transform/cast values accordingly:
 - int, float: Simple cast
 - bool: string `true`/`false` become boolean values.
 
-Default values must be simple scalar values. 
+Default values must be simple scalar values.
 They automatically make non-required fields required (and not nullable) this way, unless specified differently:
 ```xml
 defaultValue="0" required="false"
 ```
 This similar to DB and e.g. not nullable integer columns with `0` as default value.
 
-`null` is not a default value, but set via boolean `required` key independently from this and means you can set or get `null` as value.
-In PHP7.1+ this will have not an effect on default value behavior, 
-whereas in versions before it would actually (due to the language restriction) set a default value` as `null` here 
+`null` is not a default value, but set via boolean `required` key independently of this and means you can set or get `null` as value.
+Since PHP7.1+ this will have not an effect on default value behavior,
+whereas in versions before it would actually (due to the language restriction) set a default value` as `null` here
 if a typehint is used and no default value is provided:
 ```php
     /**
@@ -181,8 +181,8 @@ if a typehint is used and no default value is provided:
      */
     public function setManufactured(\Cake\I18n\FrozenDate $manufactured = null) {}
 ```
-This technically means that yu could just call the method as `->setManufactured()` and it would set it to `null` - the only way to allow nullable here.
-With PHP 7.1+ it will be a clean API with non-optional first parameter as expected then:
+This technically means that you could just call the method as `->setManufactured()` and it would set it to `null` - the only way to allow nullable here.
+It will be a clean API with non-optional first parameter as expected then:
 ```php
     /**
      * @param \Cake\I18n\FrozenDate|null $manufactured
@@ -240,7 +240,7 @@ if ($carDto->hasCar('one')) {
 // Typehinted as mixed|null
 $greenOrNull = $carsDto->read(['cars', 'one', 'color', 'green']);
 ```
- 
+
 The downside is that you lose the return type-hinting which is usually useful for static analysis.
 It should also be avoided where not needed - as you lose the auto-complete/type-hinting aspect.
 Using the class constants as field names can however compensite a bit:
@@ -368,28 +368,28 @@ Other collections most likely will not work.
 // Example for adding DTOs with associated keys
 $fooDto->addBar('a', new Bar());
 $fooDto->addBar('b', new Bar());
-  
+
 // Example for setting DTO with associated keys
 $bars = new \ArrayObject([
     'a' => new Bar(),
     'b' => new Bar(),
 ]);
 $fooDto->setBars($bars);
-  
+
 // Example for adding associated array items
 $fooDto->addBaz('x', 'X');
 $fooDto->addBaz('y', 'Y');
-  
+
 // Example for setting associated array
 $fooDto->setBazs([
     'x' => 'X',
-    'y' => 'Y', 
+    'y' => 'Y',
 ]);
-  
+
 // Example for getting associated items
 $fooDto->getBar('a'); // returns the associated Dto object to "a"
 $fooDto->getBar('c'); // throws exception because it doesn't exists
-  
+
 // Example for checking associated items
 $fooDto->hasBar('a'); // returns true
 $fooDto->hasBar('c'); // returns false
@@ -457,7 +457,7 @@ Check the [TwigView](https://github.com/WyriHaximus/TwigView) plugin which is a 
 
 
 ## Immutability
-Immutable objects can make life simpler in many cases. 
+Immutable objects can make life simpler in many cases.
 They are especially applicable for value types, where objects don't have an identity so they can be easily replaced.
 
 `immutable="true"` on the DTO makes it read only and provides `->with{Field}()` instead of setters.
@@ -513,8 +513,8 @@ You can set some defaults via `app.php` and global Configure settings:
 ```php
 return [
     'Dto' => [
-        'strictTypes' => false, // Requires PHP 7.1+
-        'scalarTypeHints' => false, // null => Auto-detect, requires PHP 7.1+
+        'strictTypes' => false,
+        'scalarTypeHints' => true,
         'immutable' => false, // This can have a negative performance impact
         'defaultCollectionType' => null, // Defaults to \ArrayObject
     ],
@@ -561,18 +561,16 @@ See the examples for details.
 
 
 ## Scalar Type Hints
-Enable more strict PHP 7.1+ typehints using Configure and `'CakeDto.scalarTypeHints'` set to  `true`.
-This will auto-cast values if needed, so this is a good intermediate solution.
-
+Typehints for scalars are added by default. Use Configure and `'CakeDto.scalarTypeHints'` set to  `false` to disable this.
 
 ## Strict Types
-With PHP 7.1+ you can generate yourself the `declare(strict_types=1)` part into the top of the PHP files.
+You can let the script generate the `declare(strict_types=1)` part into the top of the PHP files.
 `'CakeDto.strictTypes` set to  `true` will enable this.
 
 This will also stop auto-casting then. Used together with the scalar type hints you should make sure that the data
 you store in your DTOs meets those standards.
 
-I would rather recommend leaving this off and instead using the scalar type hints.
+I would rather recommend leaving this off and instead using the scalar type hints only.
 
 
 ## Debugging

--- a/docs/examples/orm.dto.xml
+++ b/docs/examples/orm.dto.xml
@@ -27,7 +27,7 @@
 
 	<dto name="MutableMeta">
 		<field name="title" type="string" required="true"/>
-		<field name="meta" type="string[]" singular="metaValue" associative="true" collectionType="array"/>
+		<field name="meta" type="?string[]" singular="metaValue" associative="true" collectionType="array"/>
 	</dto>
 
 </dtos>

--- a/src/Generator/Builder.php
+++ b/src/Generator/Builder.php
@@ -455,6 +455,7 @@ class Builder {
 			if ($fields[$key]['collection']) {
 				$fields[$key] += [
 					'singularTypeHint' => null,
+					'singularNullable' => false,
 					'singularReturnTypeHint' => null,
 				];
 				if ($fields[$key]['singularType']) {

--- a/src/Generator/Builder.php
+++ b/src/Generator/Builder.php
@@ -63,6 +63,8 @@ class Builder {
 		'toArray',
 		'collectionType',
 		'singularType',
+		'singularTypeHint',
+		'singularNullable',
 		'associative',
 		'key',
 	];
@@ -75,7 +77,7 @@ class Builder {
 
 		$this->simpleTypeWhitelist = $this->simpleTypeWhitelist($this->simpleTypeWhitelist);
 		$config = [
-			'scalarTypeHints' => Configure::read('CakeDto.scalarTypeHints', version_compare(PHP_VERSION, '7.1') >= 0),
+			'scalarTypeHints' => Configure::read('CakeDto.scalarTypeHints', true),
 			'defaultCollectionType' => Configure::read('CakeDto.defaultCollectionType', '\ArrayObject'),
 			'debug' => (bool)Configure::read('CakeDto.debug'),
 			'immutable' => (bool)Configure::read('CakeDto.immutable'),
@@ -309,9 +311,14 @@ class Builder {
 				$fields[$key]['nullable'] = false;
 
 				$fields[$key] = $this->_completeCollectionSingular($fields[$key], $dto['name'], $namespace);
+				$fields[$key]['singularNullable'] = substr($fields[$key]['type'], 0, 1) === '?';
 
 				if (preg_match('#^([A-Z][a-zA-Z/]+)\[\]$#', $field['type'], $matches)) {
 					$fields[$key]['type'] = $this->dtoTypeToClass($matches[1], $namespace) . '[]';
+				}
+
+				if ($fields[$key]['singularNullable']) {
+					$fields[$key]['type'] = '(' . $fields[$key]['singularType'] . '|null)[]';
 				}
 
 				continue;
@@ -522,6 +529,9 @@ class Builder {
 		}
 
 		$type = substr($type, 0, -2);
+		if (substr($type, 0, 1) === '?') {
+			$type = substr($type, 1);
+		}
 
 		return $this->isValidSimpleType($type) || $this->isValidDto($type) || $this->isValidInterfaceOrClass($type);
 	}
@@ -649,12 +659,8 @@ class Builder {
 	 * @return array
 	 */
 	protected function simpleTypeWhitelist(array $types): array {
-		if (version_compare(PHP_VERSION, '7.1') >= 0) {
-			$types[] = 'iterable';
-		}
-		if (version_compare(PHP_VERSION, '7.2') >= 0) {
-			$types[] = 'object';
-		}
+		$types[] = 'iterable';
+		$types[] = 'object';
 
 		return $types;
 	}
@@ -692,6 +698,10 @@ class Builder {
 		}
 
 		$type = substr($type, 0, -2);
+		if (substr($type, 0, 1) === '?') {
+			$type = substr($type, 1);
+		}
+
 		if (!$this->isValidSimpleType($type) && !$this->isValidDto($type) && !$this->isValidInterfaceOrClass($type)) {
 			return null;
 		}

--- a/src/View/Renderer.php
+++ b/src/View/Renderer.php
@@ -62,8 +62,8 @@ class Renderer {
 	 * @return void
 	 */
 	protected function setGlobalConfiguration(): void {
-		$strictTypes = (bool)Configure::read('CakeDto.strictTypes', version_compare(PHP_VERSION, '7.1') >= 0);
-		$scalarTypeHints = (bool)Configure::read('CakeDto.scalarTypeHints', version_compare(PHP_VERSION, '7.1') >= 0);
+		$strictTypes = (bool)Configure::read('CakeDto.strictTypes', false);
+		$scalarTypeHints = (bool)Configure::read('CakeDto.scalarTypeHints', true);
 
 		$this->set(compact('strictTypes', 'scalarTypeHints'));
 	}

--- a/templates/Dto/element/method_add.twig
+++ b/templates/Dto/element/method_add.twig
@@ -7,10 +7,10 @@
 {% if associative %}
 	 * @param string|int $key
 {% endif %}
-	 * @param {% if singularType %}{{ singularType }}{% else %}mixed{% endif %} ${{ singular }}
+	 * @param {% if singularType %}{{ singularType }}{% else %}mixed{% endif %}{% if singularNullable %}|null{% endif %} ${{ singular }}
 	 * @return $this
 	 */
-	public function add{{ singular[:1]|upper ~ singular[1:] }}({% if associative %}$key, {% endif %}{% if singularTypeHint %}{{ singularTypeHint }} {% endif %}${{ singular }}) {
+	public function add{{ singular[:1]|upper ~ singular[1:] }}({% if associative %}$key, {% endif %}{% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }}) {
 		if (!isset($this->{{ name }})) {
 			$this->{{ name }} = {% if collectionType == 'array' %}[]{% else %}new {{ typeHint }}([]){% endif %};
 		}

--- a/templates/Dto/element/method_add_cake_collection.twig
+++ b/templates/Dto/element/method_add_cake_collection.twig
@@ -4,11 +4,11 @@
 	 * @deprecated {{ deprecated }}
 	 *
 {% endif %}
-	 * @param {{ singularType }} ${{ singular }}
+	 * @param {{ singularType }}{% if singularNullable %}|null{% endif %} ${{ singular }}
 	 *
 	 * @return $this
 	 */
-	public function add{{ singular[:1]|upper ~ singular[1:] }}({% if singularTypeHint %}{{ singularTypeHint }} {% endif %}${{ singular }}) {
+	public function add{{ singular[:1]|upper ~ singular[1:] }}({% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }}) {
 		if (!isset($this->{{ name }})) {
 			$this->{{ name }} = new {{ typeHint }}([]);
 		}

--- a/templates/Dto/element/method_get.twig
+++ b/templates/Dto/element/method_get.twig
@@ -24,16 +24,25 @@
 {% endif %}
 	 * @param string|int $key
 	 *
-	 * @return {% if singularType %}{{ singularType }}{% else %}mixed{% endif %}
+	 * @return {% if singularType %}{{ singularType }}{% else %}mixed{% endif %}{% if singularNullable %}|null{% endif %}
 
+{% if not singularNullable %}
 	 *
 	 * @throws \RuntimeException If value with this key is not set.
+{% endif %}
 	 */
-	public function get{{ singular[:1]|upper ~ singular[1:] }}($key){% if singularReturnTypeHint %}: {% if nullable %}?{% endif %}{{ singularReturnTypeHint }}{% endif %} {
+	public function get{{ singular[:1]|upper ~ singular[1:] }}($key){% if singularReturnTypeHint %}: {% if singularNullable %}?{% endif %}{{ singularReturnTypeHint }}{% endif %} {
+{% if singularNullable %}
+		if (!isset($this->{{ name }}[$key])) {
+			return null;
+		}
+
+{% else %}
 		if (!isset($this->{{ name }}[$key])) {
 			throw new \RuntimeException(sprintf('Value not set for field `{{ name }}` and key `%s` (expected to be not null)', $key));
 		}
 
+{% endif %}
 		return $this->{{ name }}[$key];
 	}
 {% endif -%}

--- a/templates/Dto/element/method_has.twig
+++ b/templates/Dto/element/method_has.twig
@@ -20,7 +20,7 @@
 		return $this->{{ name }} !== null;
 {% endif %}
 	}
-{%- if associative %}
+{%- if associative and not singularNullable%}
 
 
 	/**

--- a/templates/Dto/element/method_with_added.twig
+++ b/templates/Dto/element/method_with_added.twig
@@ -7,10 +7,10 @@
 {% if associative %}
 	 * @param string|int $key
 {% endif %}
-	 * @param {% if returnTypeHint == 'array' %}mixed{% else %}{{ singularType }}{% endif %} ${{ singular }}
+	 * @param {% if returnTypeHint == 'array' %}mixed{% else %}{{ singularType }}{% endif %}{% if singularNullable %}|null{% endif %} ${{ singular }}
 	 * @return static
 	 */
-	public function withAdded{{ singular[:1]|upper ~ singular[1:] }}({% if associative %}$key, {% endif %}{% if singularTypeHint %}{{ singularTypeHint }} {% endif %}${{ singular }}) {
+	public function withAdded{{ singular[:1]|upper ~ singular[1:] }}({% if associative %}$key, {% endif %}{% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }}) {
 		$new = clone $this;
 
 		if (!isset($new->{{ name }})) {

--- a/templates/Dto/element/method_with_added.twig
+++ b/templates/Dto/element/method_with_added.twig
@@ -7,7 +7,7 @@
 {% if associative %}
 	 * @param string|int $key
 {% endif %}
-	 * @param {% if returnTypeHint == 'array' %}mixed{% else %}{{ singularType }}{% endif %}{% if singularNullable %}|null{% endif %} ${{ singular }}
+	 * @param {{ singularType }}{% if singularNullable %}|null{% endif %} ${{ singular }}
 	 * @return static
 	 */
 	public function withAdded{{ singular[:1]|upper ~ singular[1:] }}({% if associative %}$key, {% endif %}{% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }}) {

--- a/templates/Dto/element/method_with_added_cake_collection.twig
+++ b/templates/Dto/element/method_with_added_cake_collection.twig
@@ -7,10 +7,10 @@
 {% if associative %}
 	 * @param string|int $key
 {% endif %}
-	 * @param {% if returnTypeHint == 'array' %}mixed{% else %}{{ singularType }}{% endif %} ${{ singular }}
+	 * @param {% if returnTypeHint == 'array' %}mixed{% else %}{{ singularType }}{% endif %}{% if singularNullable %}|null{% endif %} ${{ singular }}
 	 * @return static
 	 */
-	public function withAdded{{ singular[:1]|upper ~ singular[1:] }}({% if associative %}$key, {% endif %}{% if singularTypeHint %}{{ singularTypeHint }} {% endif %}${{ singular }}) {
+	public function withAdded{{ singular[:1]|upper ~ singular[1:] }}({% if associative %}$key, {% endif %}{% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }}) {
 		$new = clone $this;
 
 		if (!isset($new->{{ name }})) {

--- a/templates/Dto/element/method_with_added_cake_collection.twig
+++ b/templates/Dto/element/method_with_added_cake_collection.twig
@@ -7,7 +7,7 @@
 {% if associative %}
 	 * @param string|int $key
 {% endif %}
-	 * @param {% if returnTypeHint == 'array' %}mixed{% else %}{{ singularType }}{% endif %}{% if singularNullable %}|null{% endif %} ${{ singular }}
+	 * @param {{ singularType }}{% if singularNullable %}|null{% endif %} ${{ singular }}
 	 * @return static
 	 */
 	public function withAdded{{ singular[:1]|upper ~ singular[1:] }}({% if associative %}$key, {% endif %}{% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }}) {

--- a/tests/TestCase/Dto/GithubTest.php
+++ b/tests/TestCase/Dto/GithubTest.php
@@ -3,6 +3,7 @@
 namespace CakeDto\Test\TestCase\Dto;
 
 use Cake\Console\ConsoleIo;
+use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use CakeDto\Shell\DtoShell;
 use Sandbox\Dto\Github\PullRequestDto;
@@ -19,11 +20,11 @@ class GithubTest extends TestCase {
 	 * @return void
 	 */
 	public function testMapping() {
-		$this->skipIf(version_compare(PHP_VERSION, '7.1') < 0, 'Requires PHP 7.1+');
-
 		$file = TESTS . 'files' . DS . 'Github' . DS . 'demo_pr.json';
 
 		$simulatedDataFromGitHubApi = json_decode(file_get_contents($file), true);
+
+		Configure::write('CakeDto.strictTypes', true);
 
 		$this->out = new ConsoleOutput();
 		$this->err = new ConsoleOutput();
@@ -112,6 +113,8 @@ class GithubTest extends TestCase {
 		];
 
 		$this->assertSame($expected, $pullRequestDtoArray);
+
+		Configure::write('CakeDto.strictTypes', false);
 	}
 
 }

--- a/tests/TestCase/Dto/GithubTest.php
+++ b/tests/TestCase/Dto/GithubTest.php
@@ -29,7 +29,7 @@ class GithubTest extends TestCase {
 		$this->out = new ConsoleOutput();
 		$this->err = new ConsoleOutput();
 		$io = new ConsoleIo($this->out, $this->err);
-		$this->shell = $this->getMockBuilder(DtoShell::class)->setMethods(['_getConfigPath', '_getSrcPath'])->setConstructorArgs([$io])->getMock();
+		$this->shell = $this->getMockBuilder(DtoShell::class)->onlyMethods(['_getConfigPath', '_getSrcPath'])->setConstructorArgs([$io])->getMock();
 
 		$sandboxPluginPath = TESTS . 'test_app' . DS . 'plugins' . DS . 'Sandbox' . DS;
 

--- a/tests/TestCase/Dto/ImmutableTest.php
+++ b/tests/TestCase/Dto/ImmutableTest.php
@@ -4,7 +4,7 @@ namespace CakeDto\Test\TestCase\Dto;
 
 use Cake\Collection\Collection;
 use Cake\Collection\CollectionInterface;
-use Cake\I18n\FrozenTime;
+use Cake\I18n\FrozenDate;
 use Cake\TestSuite\TestCase;
 use CakeDto\Dto\AbstractImmutableDto;
 use TestApp\Dto\ArticleDto;
@@ -38,7 +38,7 @@ class ImmutableTest extends TestCase {
 				'name' => 'me',
 			],
 			'title' => 'My title',
-			'created' => new FrozenTime(time() - DAY),
+			'created' => new FrozenDate(time() - DAY),
 		];
 
 		$articleDto = new ArticleDto($array);
@@ -129,8 +129,6 @@ class ImmutableTest extends TestCase {
 	 * @return void
 	 */
 	public function testPropertyAccessFails() {
-		$this->skipIf(version_compare(PHP_VERSION, '7.0') < 0, 'Fatal error before PHP 7.');
-
 		$bookDto = new BookDto();
 		$pages = $bookDto->pages;
 		$this->assertSame(0, $pages->count());

--- a/tests/TestCase/Generator/BuilderTest.php
+++ b/tests/TestCase/Generator/BuilderTest.php
@@ -71,11 +71,11 @@ class BuilderTest extends TestCase {
 		$this->assertSame($expected, array_keys($result));
 
 		$this->assertSame('Owner', $result['Car']['fields']['owner']['dto']);
-		$this->assertSame('\App\Dto\OwnerDto', $result['Car']['fields']['owner']['typeHint']);
+		$this->assertSame('?\App\Dto\OwnerDto', $result['Car']['fields']['owner']['typeHint']);
 		$this->assertSame('\Cake\I18n\FrozenDate', $result['Car']['fields']['manufactured']['type']);
 
 		$this->assertFalse($result['Car']['fields']['attributes']['collection']);
-		$this->assertSame('array', $result['Car']['fields']['attributes']['typeHint']);
+		$this->assertSame('?array', $result['Car']['fields']['attributes']['typeHint']);
 
 		$this->assertTrue($result['Cars']['fields']['cars']['collection']);
 		$this->assertSame('\ArrayObject', $result['Cars']['fields']['cars']['typeHint']);
@@ -144,7 +144,7 @@ class BuilderTest extends TestCase {
 			'collection' => false,
 			'collectionType' => null,
 			'key' => null,
-			'typeHint' => 'array',
+			'typeHint' => '?array',
 			'deprecated' => null,
 			'returnTypeHint' => 'array',
 			'serializable' => false,
@@ -159,13 +159,13 @@ class BuilderTest extends TestCase {
 			'required' => false,
 			'defaultValue' => null,
 			'nullable' => true,
-			'returnTypeHint' => null,
+			'returnTypeHint' => 'array',
 			'isArray' => true,
 			'dto' => null,
 			'collection' => false,
 			'collectionType' => null,
 			'key' => null,
-			'typeHint' => 'array',
+			'typeHint' => '?array',
 			'deprecated' => null,
 			'serializable' => false,
 			'toArray' => false,
@@ -186,12 +186,12 @@ class BuilderTest extends TestCase {
 			'collectionType' => '\ArrayObject',
 			'singular' => 'collectionAttribute',
 			'singularType' => 'string',
-			'singularTypeHint' => null,
+			'singularTypeHint' => 'string',
 			'singularNullable' => false,
-			'singularReturnTypeHint' => null,
+			'singularReturnTypeHint' => 'string',
 			'typeHint' => '\ArrayObject',
 			'deprecated' => null,
-			'returnTypeHint' => null,
+			'returnTypeHint' => '\ArrayObject',
 			'serializable' => false,
 			'toArray' => false,
 
@@ -212,12 +212,12 @@ class BuilderTest extends TestCase {
 			'key' => null,
 			'singular' => 'arrayAttribute',
 			'singularType' => 'string',
-			'singularTypeHint' => null,
+			'singularTypeHint' => 'string',
 			'singularNullable' => false,
-			'singularReturnTypeHint' => null,
+			'singularReturnTypeHint' => 'string',
 			'typeHint' => 'array',
 			'deprecated' => null,
-			'returnTypeHint' => null,
+			'returnTypeHint' => 'array',
 			'serializable' => false,
 			'toArray' => false,
 
@@ -237,13 +237,13 @@ class BuilderTest extends TestCase {
 			'collection' => true,
 			'key' => null,
 			'singularType' => 'string',
-			'singularTypeHint' => null,
+			'singularTypeHint' => 'string',
 			'singularNullable' => false,
-			'singularReturnTypeHint' => null,
+			'singularReturnTypeHint' => 'string',
 			'singular' => 'customCollectionAttribute',
 			'typeHint' => '\Cake\Collection\Collection',
 			'deprecated' => null,
-			'returnTypeHint' => null,
+			'returnTypeHint' => '\Cake\Collection\Collection',
 			'serializable' => false,
 			'toArray' => false,
 		];
@@ -262,21 +262,21 @@ class BuilderTest extends TestCase {
 			'collection' => true,
 			'key' => null,
 			'singularType' => 'string',
-			'singularTypeHint' => null,
+			'singularTypeHint' => 'string',
 			'singularNullable' => false,
-			'singularReturnTypeHint' => null,
+			'singularReturnTypeHint' => 'string',
 			'singular' => 'mySingular',
 			'typeHint' => '\ArrayObject',
 			'deprecated' => null,
-			'returnTypeHint' => null,
+			'returnTypeHint' => '\ArrayObject',
 			'serializable' => false,
 			'toArray' => false,
 		];
 		$this->assertAssociativeArraySame($expected, $result['Demo']['fields']['autoCollectionBySingular']);
 
 		$expected = [
-			'name' => 'myPlural',
-			'type' => 'string[]|\ArrayObject',
+			'name' => 'myPluralNullable',
+			'type' => '(string|null)[]|\ArrayObject',
 			'required' => false,
 			'defaultValue' => null,
 			'nullable' => false,
@@ -287,17 +287,17 @@ class BuilderTest extends TestCase {
 			'collection' => true,
 			'key' => null,
 			'singularType' => 'string',
-			'singularTypeHint' => null,
+			'singularTypeHint' => 'string',
 			'singularNullable' => true,
-			'singularReturnTypeHint' => null,
-			'singular' => 'mySingular',
+			'singularReturnTypeHint' => 'string',
+			'singular' => 'mySingularNullable',
 			'typeHint' => '\ArrayObject',
 			'deprecated' => null,
-			'returnTypeHint' => null,
+			'returnTypeHint' => '\ArrayObject',
 			'serializable' => false,
 			'toArray' => false,
 		];
-		$this->assertAssociativeArraySame($expected, $result['Demo']['fields']['autoCollectionBySingular']);
+		$this->assertAssociativeArraySame($expected, $result['Demo']['fields']['autoCollectionBySingularNullable']);
 	}
 
 	/**

--- a/tests/TestCase/Generator/BuilderTest.php
+++ b/tests/TestCase/Generator/BuilderTest.php
@@ -2,7 +2,6 @@
 
 namespace CakeDto\Test\TestCase\Generator;
 
-use Cake\Core\Configure;
 use Cake\Filesystem\Folder;
 use Cake\TestSuite\TestCase;
 use CakeDto\Engine\EngineInterface;

--- a/tests/TestCase/Generator/BuilderTest.php
+++ b/tests/TestCase/Generator/BuilderTest.php
@@ -26,8 +26,6 @@ class BuilderTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		Configure::write('CakeDto.scalarTypeHints', false);
-
 		$engine = new XmlEngine();
 		$this->builder = new Builder($engine);
 	}
@@ -39,8 +37,6 @@ class BuilderTest extends TestCase {
 		parent::tearDown();
 
 		unset($this->builder);
-
-		Configure::write('CakeDto.scalarTypeHints', false);
 	}
 
 	/**
@@ -145,7 +141,7 @@ class BuilderTest extends TestCase {
 			'key' => null,
 			'typeHint' => 'array',
 			'deprecated' => null,
-			'returnTypeHint' => null,
+			'returnTypeHint' => 'array',
 			'serializable' => false,
 			'toArray' => false,
 		];
@@ -186,6 +182,7 @@ class BuilderTest extends TestCase {
 			'singular' => 'collectionAttribute',
 			'singularType' => 'string',
 			'singularTypeHint' => null,
+			'singularNullable' => false,
 			'singularReturnTypeHint' => null,
 			'typeHint' => '\ArrayObject',
 			'deprecated' => null,
@@ -211,6 +208,7 @@ class BuilderTest extends TestCase {
 			'singular' => 'arrayAttribute',
 			'singularType' => 'string',
 			'singularTypeHint' => null,
+			'singularNullable' => false,
 			'singularReturnTypeHint' => null,
 			'typeHint' => 'array',
 			'deprecated' => null,
@@ -235,6 +233,7 @@ class BuilderTest extends TestCase {
 			'key' => null,
 			'singularType' => 'string',
 			'singularTypeHint' => null,
+			'singularNullable' => false,
 			'singularReturnTypeHint' => null,
 			'singular' => 'customCollectionAttribute',
 			'typeHint' => '\Cake\Collection\Collection',
@@ -259,6 +258,7 @@ class BuilderTest extends TestCase {
 			'key' => null,
 			'singularType' => 'string',
 			'singularTypeHint' => null,
+			'singularNullable' => false,
 			'singularReturnTypeHint' => null,
 			'singular' => 'mySingular',
 			'typeHint' => '\ArrayObject',

--- a/tests/TestCase/Generator/BuilderTest.php
+++ b/tests/TestCase/Generator/BuilderTest.php
@@ -120,6 +120,11 @@ class BuilderTest extends TestCase {
 						'type' => 'string[]',
 						'singular' => 'mySingular',
 					],
+					'autoCollectionBySingularNullable' => [
+						'name' => 'myPluralNullable',
+						'type' => '?string[]',
+						'singular' => 'mySingularNullable',
+					],
 				],
 			],
 		];
@@ -268,6 +273,31 @@ class BuilderTest extends TestCase {
 			'toArray' => false,
 		];
 		$this->assertAssociativeArraySame($expected, $result['Demo']['fields']['autoCollectionBySingular']);
+
+		$expected = [
+			'name' => 'myPlural',
+			'type' => 'string[]|\ArrayObject',
+			'required' => false,
+			'defaultValue' => null,
+			'nullable' => false,
+			'collectionType' => '\ArrayObject',
+			'isArray' => false,
+			'dto' => null,
+			'associative' => false,
+			'collection' => true,
+			'key' => null,
+			'singularType' => 'string',
+			'singularTypeHint' => null,
+			'singularNullable' => true,
+			'singularReturnTypeHint' => null,
+			'singular' => 'mySingular',
+			'typeHint' => '\ArrayObject',
+			'deprecated' => null,
+			'returnTypeHint' => null,
+			'serializable' => false,
+			'toArray' => false,
+		];
+		$this->assertAssociativeArraySame($expected, $result['Demo']['fields']['autoCollectionBySingular']);
 	}
 
 	/**
@@ -385,7 +415,7 @@ class BuilderTest extends TestCase {
 	 */
 	protected function createBuilder() {
 		$engine = $this->getMockBuilder(EngineInterface::class)->getMock();
-		$builder = $this->getMockBuilder(Builder::class)->setMethods(['_merge', '_getFiles'])->setConstructorArgs([$engine])->getMock();
+		$builder = $this->getMockBuilder(Builder::class)->onlyMethods(['_merge', '_getFiles'])->setConstructorArgs([$engine])->getMock();
 		$builder->expects($this->any())->method('_getFiles')->willReturn([]);
 
 		return $builder;

--- a/tests/TestCase/Generator/GeneratorTest.php
+++ b/tests/TestCase/Generator/GeneratorTest.php
@@ -49,8 +49,6 @@ class GeneratorTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		Configure::write('CakeDto.scalarTypeHints', false);
-
 		$this->generator = $this->createGenerator();
 
 		$this->prepareDirectories();
@@ -63,8 +61,6 @@ class GeneratorTest extends TestCase {
 		parent::tearDown();
 
 		unset($this->generator);
-
-		Configure::write('CakeDto.scalarTypeHints', false);
 	}
 
 	/**
@@ -181,12 +177,9 @@ TXT;
 	 * @return void
 	 */
 	public function testScalarTypeHints() {
-		$this->skipIf(version_compare(PHP_VERSION, '7.1') < 0, 'Requires PHP 7.1+');
-
 		$xml = ROOT . DS . 'docs/examples/basic.dto.xml';
 		copy($xml, $this->configPath . 'dto.xml');
 
-		Configure::write('CakeDto.scalarTypeHints', true);
 		$this->generator = $this->createGenerator();
 
 		$options = [
@@ -222,8 +215,6 @@ TXT;
 	 * @return void
 	 */
 	public function testScalarTypeHintsDefaultValueRequiredFalse() {
-		$this->skipIf(version_compare(PHP_VERSION, '7.1') < 0, 'Requires PHP 7.1+');
-
 		$xml = ROOT . DS . 'tests/files/xml/scalar_default_required_false.xml';
 		copy($xml, $this->configPath . 'dto.xml');
 

--- a/tests/TestCase/Generator/GeneratorTest.php
+++ b/tests/TestCase/Generator/GeneratorTest.php
@@ -70,9 +70,12 @@ class GeneratorTest extends TestCase {
 		$exampleXml = ROOT . DS . 'docs/examples/basic.dto.xml';
 		copy($exampleXml, $this->configPath . 'dto.xml');
 
+		Configure::write('CakeDto.scalarTypeHints', false);
+
 		$options = [
 			'confirm' => true,
 		];
+		$this->generator = $this->createGenerator();
 		$result = $this->generator->generate($this->configPath, $this->srcPath, $options);
 
 		$this->assertSame(2, $result);
@@ -91,6 +94,8 @@ class GeneratorTest extends TestCase {
 		$this->assertTemplateContains('CarDto.set', $file);
 		$this->assertTemplateContains('CarDto.has', $file);
 		$this->assertTemplateContains('CarDto.get_or_fail', $file);
+
+		Configure::delete('CakeDto.scalarTypeHints');
 	}
 
 	/**
@@ -121,10 +126,13 @@ class GeneratorTest extends TestCase {
 		$xml = ROOT . DS . 'tests/files/xml/deprecated.xml';
 		copy($xml, $this->configPath . 'dto.xml');
 
+		Configure::write('CakeDto.scalarTypeHints', false);
+
 		$options = [
 			'confirm' => true,
 			'force' => true,
 		];
+		$this->generator = $this->createGenerator();
 		$result = $this->generator->generate($this->configPath, $this->srcPath, $options);
 
 		$this->assertSame(2, $result);
@@ -136,6 +144,8 @@ class GeneratorTest extends TestCase {
 		$file = $this->srcPath . 'Dto' . DS . 'AnimalDto.php';
 		$this->assertTemplateContains('AnimalDto.dto', $file);
 		$this->assertTemplateContainsCount('@deprecated', 1, $file);
+
+		Configure::delete('CakeDto.scalarTypeHints');
 	}
 
 	/**

--- a/tests/TestCase/Shell/DtoShellTest.php
+++ b/tests/TestCase/Shell/DtoShellTest.php
@@ -34,7 +34,7 @@ class DtoShellTest extends TestCase {
 		$this->out = new ConsoleOutput();
 		$this->err = new ConsoleOutput();
 		$io = new ConsoleIo($this->out, $this->err);
-		$this->shell = $this->getMockBuilder(DtoShell::class)->setMethods(['_getConfigPath', '_getSrcPath'])->setConstructorArgs([$io])->getMock();
+		$this->shell = $this->getMockBuilder(DtoShell::class)->onlyMethods(['_getConfigPath', '_getSrcPath'])->setConstructorArgs([$io])->getMock();
 
 		$tmp = TMP . 'shell' . DS;
 		$folder = new Folder($tmp);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -46,4 +46,3 @@ Cake\Core\Configure::write('CakeDto', [
 Cake\Core\Configure::write('debug', true);
 
 Cake\Core\Plugin::getCollection()->add(new CakeDto\Plugin());
-//Cake\Core\Plugin::load('WyriHaximus/TwigView', ['path' => ROOT . DS . 'vendor/wyrihaximus/twig-view/', 'autoload' => true, 'bootstrap' => true]);

--- a/tests/generate.php
+++ b/tests/generate.php
@@ -12,7 +12,7 @@ use CakeDto\Generator\Builder;
 use CakeDto\Generator\Generator;
 use CakeDto\View\Renderer;
 
-Configure::write('CakeDto.scalarTypeHints', false);
+Configure::write('CakeDto.scalarTypeHints', true);
 Configure::write('CakeDto.strictTypes', false);
 
 $engine = new XmlEngine();

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/PullRequestDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/PullRequestDto.php
@@ -186,6 +186,8 @@ class PullRequestDto extends \CakeDto\Dto\AbstractDto {
 			'serializable' => false,
 			'toArray' => false,
 			'singularType' => '\Sandbox\Dto\Github\LabelDto',
+			'singularNullable' => false,
+			'singularTypeHint' => '\Sandbox\Dto\Github\LabelDto',
 		],
 		'head' => [
 			'name' => 'head',

--- a/tests/test_app/src/Dto/ArticleDto.php
+++ b/tests/test_app/src/Dto/ArticleDto.php
@@ -307,7 +307,7 @@ class ArticleDto extends \CakeDto\Dto\AbstractImmutableDto {
 		return count($this->tags) > 0;
 	}
 	/**
-	 * @param mixed $tag
+	 * @param \TestApp\Dto\TagDto $tag
 	 * @return static
 	 */
 	public function withAddedTag(\TestApp\Dto\TagDto $tag) {
@@ -383,7 +383,7 @@ class ArticleDto extends \CakeDto\Dto\AbstractImmutableDto {
 
 	/**
 	 * @param string|int $key
-	 * @param mixed $metaValue
+	 * @param string $metaValue
 	 * @return static
 	 */
 	public function withAddedMetaValue($key, string $metaValue) {

--- a/tests/test_app/src/Dto/ArticleDto.php
+++ b/tests/test_app/src/Dto/ArticleDto.php
@@ -18,12 +18,12 @@ namespace TestApp\Dto;
  */
 class ArticleDto extends \CakeDto\Dto\AbstractImmutableDto {
 
-	const FIELD_ID = 'id';
-	const FIELD_AUTHOR = 'author';
-	const FIELD_TITLE = 'title';
-	const FIELD_CREATED = 'created';
-	const FIELD_TAGS = 'tags';
-	const FIELD_META = 'meta';
+	public const FIELD_ID = 'id';
+	public const FIELD_AUTHOR = 'author';
+	public const FIELD_TITLE = 'title';
+	public const FIELD_CREATED = 'created';
+	public const FIELD_TAGS = 'tags';
+	public const FIELD_META = 'meta';
 
 	/**
 	 * @var int
@@ -122,6 +122,8 @@ class ArticleDto extends \CakeDto\Dto\AbstractImmutableDto {
 			'serializable' => false,
 			'toArray' => false,
 			'singularType' => '\TestApp\Dto\TagDto',
+			'singularNullable' => false,
+			'singularTypeHint' => '\TestApp\Dto\TagDto',
 		],
 		'meta' => [
 			'name' => 'meta',
@@ -135,6 +137,8 @@ class ArticleDto extends \CakeDto\Dto\AbstractImmutableDto {
 			'serializable' => false,
 			'toArray' => false,
 			'singularType' => 'string',
+			'singularNullable' => false,
+			'singularTypeHint' => 'string',
 		],
 	];
 
@@ -165,7 +169,7 @@ class ArticleDto extends \CakeDto\Dto\AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withId($id) {
+	public function withId(int $id) {
 		$new = clone $this;
 		$new->id = $id;
 		$new->_touchedFields[self::FIELD_ID] = true;
@@ -176,14 +180,14 @@ class ArticleDto extends \CakeDto\Dto\AbstractImmutableDto {
 	/**
 	 * @return int
 	 */
-	public function getId() {
+	public function getId(): int {
 		return $this->id;
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function hasId() {
+	public function hasId(): bool {
 		return $this->id !== null;
 	}
 
@@ -203,14 +207,14 @@ class ArticleDto extends \CakeDto\Dto\AbstractImmutableDto {
 	/**
 	 * @return \TestApp\Dto\AuthorDto
 	 */
-	public function getAuthor() {
+	public function getAuthor(): \TestApp\Dto\AuthorDto {
 		return $this->author;
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function hasAuthor() {
+	public function hasAuthor(): bool {
 		return $this->author !== null;
 	}
 
@@ -219,7 +223,7 @@ class ArticleDto extends \CakeDto\Dto\AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withTitle($title) {
+	public function withTitle(string $title) {
 		$new = clone $this;
 		$new->title = $title;
 		$new->_touchedFields[self::FIELD_TITLE] = true;
@@ -230,14 +234,14 @@ class ArticleDto extends \CakeDto\Dto\AbstractImmutableDto {
 	/**
 	 * @return string
 	 */
-	public function getTitle() {
+	public function getTitle(): string {
 		return $this->title;
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function hasTitle() {
+	public function hasTitle(): bool {
 		return $this->title !== null;
 	}
 
@@ -257,14 +261,14 @@ class ArticleDto extends \CakeDto\Dto\AbstractImmutableDto {
 	/**
 	 * @return \Cake\I18n\FrozenDate
 	 */
-	public function getCreated() {
+	public function getCreated(): \Cake\I18n\FrozenDate {
 		return $this->created;
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function hasCreated() {
+	public function hasCreated(): bool {
 		return $this->created !== null;
 	}
 
@@ -284,7 +288,7 @@ class ArticleDto extends \CakeDto\Dto\AbstractImmutableDto {
 	/**
 	 * @return \TestApp\Dto\TagDto[]
 	 */
-	public function getTags() {
+	public function getTags(): array {
 		if ($this->tags === null) {
 			return [];
 		}
@@ -295,7 +299,7 @@ class ArticleDto extends \CakeDto\Dto\AbstractImmutableDto {
 	/**
 	 * @return bool
 	 */
-	public function hasTags() {
+	public function hasTags(): bool {
 		if ($this->tags === null) {
 			return false;
 		}
@@ -303,7 +307,7 @@ class ArticleDto extends \CakeDto\Dto\AbstractImmutableDto {
 		return count($this->tags) > 0;
 	}
 	/**
-	 * @param \TestApp\Dto\TagDto $tag
+	 * @param mixed $tag
 	 * @return static
 	 */
 	public function withAddedTag(\TestApp\Dto\TagDto $tag) {
@@ -335,7 +339,7 @@ class ArticleDto extends \CakeDto\Dto\AbstractImmutableDto {
 	/**
 	 * @return string[]
 	 */
-	public function getMeta() {
+	public function getMeta(): array {
 		if ($this->meta === null) {
 			return [];
 		}
@@ -350,7 +354,7 @@ class ArticleDto extends \CakeDto\Dto\AbstractImmutableDto {
 	 *
 	 * @throws \RuntimeException If value with this key is not set.
 	 */
-	public function getMetaValue($key) {
+	public function getMetaValue($key): string {
 		if (!isset($this->meta[$key])) {
 			throw new \RuntimeException(sprintf('Value not set for field `meta` and key `%s` (expected to be not null)', $key));
 		}
@@ -361,7 +365,7 @@ class ArticleDto extends \CakeDto\Dto\AbstractImmutableDto {
 	/**
 	 * @return bool
 	 */
-	public function hasMeta() {
+	public function hasMeta(): bool {
 		if ($this->meta === null) {
 			return false;
 		}
@@ -373,16 +377,16 @@ class ArticleDto extends \CakeDto\Dto\AbstractImmutableDto {
 	 * @param string|int $key
 	 * @return bool
 	 */
-	public function hasMetaValue($key) {
+	public function hasMetaValue($key): bool {
 		return isset($this->meta[$key]);
 	}
 
 	/**
 	 * @param string|int $key
-	 * @param string $metaValue
+	 * @param mixed $metaValue
 	 * @return static
 	 */
-	public function withAddedMetaValue($key, $metaValue) {
+	public function withAddedMetaValue($key, string $metaValue) {
 		$new = clone $this;
 
 		if (!isset($new->meta)) {

--- a/tests/test_app/src/Dto/AuthorDto.php
+++ b/tests/test_app/src/Dto/AuthorDto.php
@@ -15,9 +15,9 @@ namespace TestApp\Dto;
  */
 class AuthorDto extends \CakeDto\Dto\AbstractImmutableDto {
 
-	const FIELD_ID = 'id';
-	const FIELD_NAME = 'name';
-	const FIELD_EMAIL = 'email';
+	public const FIELD_ID = 'id';
+	public const FIELD_NAME = 'name';
+	public const FIELD_EMAIL = 'email';
 
 	/**
 	 * @var int
@@ -99,7 +99,7 @@ class AuthorDto extends \CakeDto\Dto\AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withId($id) {
+	public function withId(int $id) {
 		$new = clone $this;
 		$new->id = $id;
 		$new->_touchedFields[self::FIELD_ID] = true;
@@ -110,14 +110,14 @@ class AuthorDto extends \CakeDto\Dto\AbstractImmutableDto {
 	/**
 	 * @return int
 	 */
-	public function getId() {
+	public function getId(): int {
 		return $this->id;
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function hasId() {
+	public function hasId(): bool {
 		return $this->id !== null;
 	}
 
@@ -126,7 +126,7 @@ class AuthorDto extends \CakeDto\Dto\AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withName($name) {
+	public function withName(string $name) {
 		$new = clone $this;
 		$new->name = $name;
 		$new->_touchedFields[self::FIELD_NAME] = true;
@@ -137,14 +137,14 @@ class AuthorDto extends \CakeDto\Dto\AbstractImmutableDto {
 	/**
 	 * @return string
 	 */
-	public function getName() {
+	public function getName(): string {
 		return $this->name;
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function hasName() {
+	public function hasName(): bool {
 		return $this->name !== null;
 	}
 
@@ -153,7 +153,7 @@ class AuthorDto extends \CakeDto\Dto\AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withEmail($email) {
+	public function withEmail(?string $email = null) {
 		$new = clone $this;
 		$new->email = $email;
 		$new->_touchedFields[self::FIELD_EMAIL] = true;
@@ -164,7 +164,7 @@ class AuthorDto extends \CakeDto\Dto\AbstractImmutableDto {
 	/**
 	 * @return string|null
 	 */
-	public function getEmail() {
+	public function getEmail(): ?string {
 		return $this->email;
 	}
 
@@ -173,7 +173,7 @@ class AuthorDto extends \CakeDto\Dto\AbstractImmutableDto {
 	 *
 	 * @return string
 	 */
-	public function getEmailOrFail() {
+	public function getEmailOrFail(): string {
 		if (!isset($this->email)) {
 			throw new \RuntimeException('Value not set for field `email` (expected to be not null)');
 		}
@@ -184,7 +184,7 @@ class AuthorDto extends \CakeDto\Dto\AbstractImmutableDto {
 	/**
 	 * @return bool
 	 */
-	public function hasEmail() {
+	public function hasEmail(): bool {
 		return $this->email !== null;
 	}
 

--- a/tests/test_app/src/Dto/BookDto.php
+++ b/tests/test_app/src/Dto/BookDto.php
@@ -13,7 +13,7 @@ namespace TestApp\Dto;
  */
 class BookDto extends \CakeDto\Dto\AbstractImmutableDto {
 
-	const FIELD_PAGES = 'pages';
+	public const FIELD_PAGES = 'pages';
 
 	/**
 	 * @var \TestApp\Dto\PageDto[]|\Cake\Collection\Collection
@@ -38,6 +38,8 @@ class BookDto extends \CakeDto\Dto\AbstractImmutableDto {
 			'serializable' => false,
 			'toArray' => false,
 			'singularType' => '\TestApp\Dto\PageDto',
+			'singularNullable' => false,
+			'singularTypeHint' => '\TestApp\Dto\PageDto',
 		],
 	];
 
@@ -69,7 +71,7 @@ class BookDto extends \CakeDto\Dto\AbstractImmutableDto {
 	/**
 	 * @return \TestApp\Dto\PageDto[]|\Cake\Collection\Collection
 	 */
-	public function getPages() {
+	public function getPages(): \Cake\Collection\Collection {
 		if ($this->pages === null) {
 			return new \Cake\Collection\Collection([]);
 		}
@@ -80,7 +82,7 @@ class BookDto extends \CakeDto\Dto\AbstractImmutableDto {
 	/**
 	 * @return bool
 	 */
-	public function hasPages() {
+	public function hasPages(): bool {
 		if ($this->pages === null) {
 			return false;
 		}

--- a/tests/test_app/src/Dto/CarDto.php
+++ b/tests/test_app/src/Dto/CarDto.php
@@ -19,13 +19,13 @@ namespace TestApp\Dto;
  */
 class CarDto extends \CakeDto\Dto\AbstractDto {
 
-	const FIELD_COLOR = 'color';
-	const FIELD_IS_NEW = 'isNew';
-	const FIELD_VALUE = 'value';
-	const FIELD_DISTANCE_TRAVELLED = 'distanceTravelled';
-	const FIELD_ATTRIBUTES = 'attributes';
-	const FIELD_MANUFACTURED = 'manufactured';
-	const FIELD_OWNER = 'owner';
+	public const FIELD_COLOR = 'color';
+	public const FIELD_IS_NEW = 'isNew';
+	public const FIELD_VALUE = 'value';
+	public const FIELD_DISTANCE_TRAVELLED = 'distanceTravelled';
+	public const FIELD_ATTRIBUTES = 'attributes';
+	public const FIELD_MANUFACTURED = 'manufactured';
+	public const FIELD_OWNER = 'owner';
 
 	/**
 	 * @var \TestApp\ValueObject\Paint|null
@@ -185,7 +185,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setColor(\TestApp\ValueObject\Paint $color = null) {
+	public function setColor(?\TestApp\ValueObject\Paint $color) {
 		$this->color = $color;
 		$this->_touchedFields[self::FIELD_COLOR] = true;
 
@@ -195,7 +195,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @return \TestApp\ValueObject\Paint|null
 	 */
-	public function getColor() {
+	public function getColor(): ?\TestApp\ValueObject\Paint {
 		return $this->color;
 	}
 
@@ -204,7 +204,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	 *
 	 * @return \TestApp\ValueObject\Paint
 	 */
-	public function getColorOrFail() {
+	public function getColorOrFail(): \TestApp\ValueObject\Paint {
 		if (!isset($this->color)) {
 			throw new \RuntimeException('Value not set for field `color` (expected to be not null)');
 		}
@@ -215,7 +215,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @return bool
 	 */
-	public function hasColor() {
+	public function hasColor(): bool {
 		return $this->color !== null;
 	}
 
@@ -224,7 +224,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setIsNew($isNew) {
+	public function setIsNew(?bool $isNew) {
 		$this->isNew = $isNew;
 		$this->_touchedFields[self::FIELD_IS_NEW] = true;
 
@@ -234,7 +234,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @return bool|null
 	 */
-	public function getIsNew() {
+	public function getIsNew(): ?bool {
 		return $this->isNew;
 	}
 
@@ -243,7 +243,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	 *
 	 * @return bool
 	 */
-	public function getIsNewOrFail() {
+	public function getIsNewOrFail(): bool {
 		if (!isset($this->isNew)) {
 			throw new \RuntimeException('Value not set for field `isNew` (expected to be not null)');
 		}
@@ -254,7 +254,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @return bool
 	 */
-	public function hasIsNew() {
+	public function hasIsNew(): bool {
 		return $this->isNew !== null;
 	}
 
@@ -263,7 +263,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setValue($value) {
+	public function setValue(?float $value) {
 		$this->value = $value;
 		$this->_touchedFields[self::FIELD_VALUE] = true;
 
@@ -273,7 +273,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @return float|null
 	 */
-	public function getValue() {
+	public function getValue(): ?float {
 		return $this->value;
 	}
 
@@ -282,7 +282,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	 *
 	 * @return float
 	 */
-	public function getValueOrFail() {
+	public function getValueOrFail(): float {
 		if (!isset($this->value)) {
 			throw new \RuntimeException('Value not set for field `value` (expected to be not null)');
 		}
@@ -293,7 +293,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @return bool
 	 */
-	public function hasValue() {
+	public function hasValue(): bool {
 		return $this->value !== null;
 	}
 
@@ -302,7 +302,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setDistanceTravelled($distanceTravelled) {
+	public function setDistanceTravelled(?int $distanceTravelled) {
 		$this->distanceTravelled = $distanceTravelled;
 		$this->_touchedFields[self::FIELD_DISTANCE_TRAVELLED] = true;
 
@@ -312,7 +312,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @return int|null
 	 */
-	public function getDistanceTravelled() {
+	public function getDistanceTravelled(): ?int {
 		return $this->distanceTravelled;
 	}
 
@@ -321,7 +321,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	 *
 	 * @return int
 	 */
-	public function getDistanceTravelledOrFail() {
+	public function getDistanceTravelledOrFail(): int {
 		if (!isset($this->distanceTravelled)) {
 			throw new \RuntimeException('Value not set for field `distanceTravelled` (expected to be not null)');
 		}
@@ -332,7 +332,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @return bool
 	 */
-	public function hasDistanceTravelled() {
+	public function hasDistanceTravelled(): bool {
 		return $this->distanceTravelled !== null;
 	}
 
@@ -341,7 +341,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setAttributes(array $attributes = null) {
+	public function setAttributes(?array $attributes) {
 		$this->attributes = $attributes;
 		$this->_touchedFields[self::FIELD_ATTRIBUTES] = true;
 
@@ -351,7 +351,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @return string[]|null
 	 */
-	public function getAttributes() {
+	public function getAttributes(): ?array {
 		return $this->attributes;
 	}
 
@@ -360,7 +360,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	 *
 	 * @return string[]
 	 */
-	public function getAttributesOrFail() {
+	public function getAttributesOrFail(): array {
 		if (!isset($this->attributes)) {
 			throw new \RuntimeException('Value not set for field `attributes` (expected to be not null)');
 		}
@@ -371,7 +371,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @return bool
 	 */
-	public function hasAttributes() {
+	public function hasAttributes(): bool {
 		return $this->attributes !== null;
 	}
 
@@ -380,7 +380,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setManufactured(\Cake\I18n\FrozenDate $manufactured = null) {
+	public function setManufactured(?\Cake\I18n\FrozenDate $manufactured) {
 		$this->manufactured = $manufactured;
 		$this->_touchedFields[self::FIELD_MANUFACTURED] = true;
 
@@ -390,7 +390,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @return \Cake\I18n\FrozenDate|null
 	 */
-	public function getManufactured() {
+	public function getManufactured(): ?\Cake\I18n\FrozenDate {
 		return $this->manufactured;
 	}
 
@@ -399,7 +399,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	 *
 	 * @return \Cake\I18n\FrozenDate
 	 */
-	public function getManufacturedOrFail() {
+	public function getManufacturedOrFail(): \Cake\I18n\FrozenDate {
 		if (!isset($this->manufactured)) {
 			throw new \RuntimeException('Value not set for field `manufactured` (expected to be not null)');
 		}
@@ -410,7 +410,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @return bool
 	 */
-	public function hasManufactured() {
+	public function hasManufactured(): bool {
 		return $this->manufactured !== null;
 	}
 
@@ -419,7 +419,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setOwner(\TestApp\Dto\OwnerDto $owner = null) {
+	public function setOwner(?\TestApp\Dto\OwnerDto $owner) {
 		$this->owner = $owner;
 		$this->_touchedFields[self::FIELD_OWNER] = true;
 
@@ -429,7 +429,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @return \TestApp\Dto\OwnerDto|null
 	 */
-	public function getOwner() {
+	public function getOwner(): ?\TestApp\Dto\OwnerDto {
 		return $this->owner;
 	}
 
@@ -438,7 +438,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	 *
 	 * @return \TestApp\Dto\OwnerDto
 	 */
-	public function getOwnerOrFail() {
+	public function getOwnerOrFail(): \TestApp\Dto\OwnerDto {
 		if (!isset($this->owner)) {
 			throw new \RuntimeException('Value not set for field `owner` (expected to be not null)');
 		}
@@ -449,7 +449,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @return bool
 	 */
-	public function hasOwner() {
+	public function hasOwner(): bool {
 		return $this->owner !== null;
 	}
 

--- a/tests/test_app/src/Dto/CarsDto.php
+++ b/tests/test_app/src/Dto/CarsDto.php
@@ -13,7 +13,7 @@ namespace TestApp\Dto;
  */
 class CarsDto extends \CakeDto\Dto\AbstractDto {
 
-	const FIELD_CARS = 'cars';
+	public const FIELD_CARS = 'cars';
 
 	/**
 	 * @var \TestApp\Dto\CarDto[]|\ArrayObject
@@ -38,6 +38,8 @@ class CarsDto extends \CakeDto\Dto\AbstractDto {
 			'serializable' => false,
 			'toArray' => false,
 			'singularType' => '\TestApp\Dto\CarDto',
+			'singularNullable' => false,
+			'singularTypeHint' => '\TestApp\Dto\CarDto',
 		],
 	];
 
@@ -68,7 +70,7 @@ class CarsDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @return \TestApp\Dto\CarDto[]|\ArrayObject
 	 */
-	public function getCars() {
+	public function getCars(): \ArrayObject {
 		if ($this->cars === null) {
 			return new \ArrayObject([]);
 		}
@@ -83,7 +85,7 @@ class CarsDto extends \CakeDto\Dto\AbstractDto {
 	 *
 	 * @throws \RuntimeException If value with this key is not set.
 	 */
-	public function getCar($key) {
+	public function getCar($key): \TestApp\Dto\CarDto {
 		if (!isset($this->cars[$key])) {
 			throw new \RuntimeException(sprintf('Value not set for field `cars` and key `%s` (expected to be not null)', $key));
 		}
@@ -94,7 +96,7 @@ class CarsDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @return bool
 	 */
-	public function hasCars() {
+	public function hasCars(): bool {
 		if ($this->cars === null) {
 			return false;
 		}
@@ -106,7 +108,7 @@ class CarsDto extends \CakeDto\Dto\AbstractDto {
 	 * @param string|int $key
 	 * @return bool
 	 */
-	public function hasCar($key) {
+	public function hasCar($key): bool {
 		return isset($this->cars[$key]);
 	}
 

--- a/tests/test_app/src/Dto/CustomerAccountDto.php
+++ b/tests/test_app/src/Dto/CustomerAccountDto.php
@@ -14,8 +14,8 @@ namespace TestApp\Dto;
  */
 class CustomerAccountDto extends \CakeDto\Dto\AbstractDto {
 
-	const FIELD_CUSTOMER_NAME = 'customerName';
-	const FIELD_BIRTH_YEAR = 'birthYear';
+	public const FIELD_CUSTOMER_NAME = 'customerName';
+	public const FIELD_BIRTH_YEAR = 'birthYear';
 
 	/**
 	 * @var string
@@ -78,7 +78,7 @@ class CustomerAccountDto extends \CakeDto\Dto\AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setCustomerName($customerName) {
+	public function setCustomerName(string $customerName) {
 		$this->customerName = $customerName;
 		$this->_touchedFields[self::FIELD_CUSTOMER_NAME] = true;
 
@@ -88,14 +88,14 @@ class CustomerAccountDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @return string
 	 */
-	public function getCustomerName() {
+	public function getCustomerName(): string {
 		return $this->customerName;
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function hasCustomerName() {
+	public function hasCustomerName(): bool {
 		return $this->customerName !== null;
 	}
 
@@ -104,7 +104,7 @@ class CustomerAccountDto extends \CakeDto\Dto\AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setBirthYear($birthYear) {
+	public function setBirthYear(?int $birthYear) {
 		$this->birthYear = $birthYear;
 		$this->_touchedFields[self::FIELD_BIRTH_YEAR] = true;
 
@@ -114,7 +114,7 @@ class CustomerAccountDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @return int|null
 	 */
-	public function getBirthYear() {
+	public function getBirthYear(): ?int {
 		return $this->birthYear;
 	}
 
@@ -123,7 +123,7 @@ class CustomerAccountDto extends \CakeDto\Dto\AbstractDto {
 	 *
 	 * @return int
 	 */
-	public function getBirthYearOrFail() {
+	public function getBirthYearOrFail(): int {
 		if (!isset($this->birthYear)) {
 			throw new \RuntimeException('Value not set for field `birthYear` (expected to be not null)');
 		}
@@ -134,7 +134,7 @@ class CustomerAccountDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @return bool
 	 */
-	public function hasBirthYear() {
+	public function hasBirthYear(): bool {
 		return $this->birthYear !== null;
 	}
 

--- a/tests/test_app/src/Dto/FlyingCarDto.php
+++ b/tests/test_app/src/Dto/FlyingCarDto.php
@@ -15,9 +15,9 @@ namespace TestApp\Dto;
  */
 class FlyingCarDto extends CarDto {
 
-	const FIELD_MAX_ALTITUDE = 'maxAltitude';
-	const FIELD_MAX_SPEED = 'maxSpeed';
-	const FIELD_COMPLEX_ATTRIBUTES = 'complexAttributes';
+	public const FIELD_MAX_ALTITUDE = 'maxAltitude';
+	public const FIELD_MAX_SPEED = 'maxSpeed';
+	public const FIELD_COMPLEX_ATTRIBUTES = 'complexAttributes';
 
 	/**
 	 * @var int
@@ -99,7 +99,7 @@ class FlyingCarDto extends CarDto {
 	 *
 	 * @return $this
 	 */
-	public function setMaxAltitude($maxAltitude) {
+	public function setMaxAltitude(int $maxAltitude) {
 		$this->maxAltitude = $maxAltitude;
 		$this->_touchedFields[self::FIELD_MAX_ALTITUDE] = true;
 
@@ -109,7 +109,7 @@ class FlyingCarDto extends CarDto {
 	/**
 	 * @return int
 	 */
-	public function getMaxAltitude() {
+	public function getMaxAltitude(): int {
 		return $this->maxAltitude;
 	}
 
@@ -119,7 +119,7 @@ class FlyingCarDto extends CarDto {
 	 *
 	 * @return $this
 	 */
-	public function setMaxSpeed($maxSpeed) {
+	public function setMaxSpeed(int $maxSpeed) {
 		$this->maxSpeed = $maxSpeed;
 		$this->_touchedFields[self::FIELD_MAX_SPEED] = true;
 
@@ -129,7 +129,7 @@ class FlyingCarDto extends CarDto {
 	/**
 	 * @return int
 	 */
-	public function getMaxSpeed() {
+	public function getMaxSpeed(): int {
 		return $this->maxSpeed;
 	}
 
@@ -139,7 +139,7 @@ class FlyingCarDto extends CarDto {
 	 *
 	 * @return $this
 	 */
-	public function setComplexAttributes(array $complexAttributes = null) {
+	public function setComplexAttributes(?array $complexAttributes) {
 		$this->complexAttributes = $complexAttributes;
 		$this->_touchedFields[self::FIELD_COMPLEX_ATTRIBUTES] = true;
 
@@ -149,7 +149,7 @@ class FlyingCarDto extends CarDto {
 	/**
 	 * @return array|null
 	 */
-	public function getComplexAttributes() {
+	public function getComplexAttributes(): ?array {
 		return $this->complexAttributes;
 	}
 
@@ -158,7 +158,7 @@ class FlyingCarDto extends CarDto {
 	 *
 	 * @return array
 	 */
-	public function getComplexAttributesOrFail() {
+	public function getComplexAttributesOrFail(): array {
 		if (!isset($this->complexAttributes)) {
 			throw new \RuntimeException('Value not set for field `complexAttributes` (expected to be not null)');
 		}
@@ -169,7 +169,7 @@ class FlyingCarDto extends CarDto {
 	/**
 	 * @return bool
 	 */
-	public function hasComplexAttributes() {
+	public function hasComplexAttributes(): bool {
 		return $this->complexAttributes !== null;
 	}
 

--- a/tests/test_app/src/Dto/MutableMetaDto.php
+++ b/tests/test_app/src/Dto/MutableMetaDto.php
@@ -10,12 +10,12 @@ namespace TestApp\Dto;
  * MutableMeta DTO
  *
  * @property string $title
- * @property string[] $meta
+ * @property (string|null)[] $meta
  */
 class MutableMetaDto extends \CakeDto\Dto\AbstractDto {
 
-	const FIELD_TITLE = 'title';
-	const FIELD_META = 'meta';
+	public const FIELD_TITLE = 'title';
+	public const FIELD_META = 'meta';
 
 	/**
 	 * @var string
@@ -23,7 +23,7 @@ class MutableMetaDto extends \CakeDto\Dto\AbstractDto {
 	protected $title;
 
 	/**
-	 * @var string[]
+	 * @var (string|null)[]
 	 */
 	protected $meta;
 
@@ -47,7 +47,7 @@ class MutableMetaDto extends \CakeDto\Dto\AbstractDto {
 		],
 		'meta' => [
 			'name' => 'meta',
-			'type' => 'string[]',
+			'type' => '(string|null)[]',
 			'associative' => true,
 			'collectionType' => 'array',
 			'required' => false,
@@ -57,6 +57,8 @@ class MutableMetaDto extends \CakeDto\Dto\AbstractDto {
 			'serializable' => false,
 			'toArray' => false,
 			'singularType' => 'string',
+			'singularNullable' => true,
+			'singularTypeHint' => 'string',
 		],
 	];
 
@@ -79,7 +81,7 @@ class MutableMetaDto extends \CakeDto\Dto\AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setTitle($title) {
+	public function setTitle(string $title) {
 		$this->title = $title;
 		$this->_touchedFields[self::FIELD_TITLE] = true;
 
@@ -89,19 +91,19 @@ class MutableMetaDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @return string
 	 */
-	public function getTitle() {
+	public function getTitle(): string {
 		return $this->title;
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function hasTitle() {
+	public function hasTitle(): bool {
 		return $this->title !== null;
 	}
 
 	/**
-	 * @param string[] $meta
+	 * @param (string|null)[] $meta
 	 *
 	 * @return $this
 	 */
@@ -113,9 +115,9 @@ class MutableMetaDto extends \CakeDto\Dto\AbstractDto {
 	}
 
 	/**
-	 * @return string[]
+	 * @return (string|null)[]
 	 */
-	public function getMeta() {
+	public function getMeta(): array {
 		if ($this->meta === null) {
 			return [];
 		}
@@ -126,13 +128,13 @@ class MutableMetaDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @param string|int $key
 	 *
-	 * @return string
+	 * @return string|null
 	 *
 	 * @throws \RuntimeException If value with this key is not set.
 	 */
-	public function getMetaValue($key) {
+	public function getMetaValue($key): ?string {
 		if (!isset($this->meta[$key])) {
-			throw new \RuntimeException(sprintf('Value not set for field `meta` and key `%s` (expected to be not null)', $key));
+			return null;
 		}
 
 		return $this->meta[$key];
@@ -141,28 +143,19 @@ class MutableMetaDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @return bool
 	 */
-	public function hasMeta() {
+	public function hasMeta(): bool {
 		if ($this->meta === null) {
 			return false;
 		}
 
 		return count($this->meta) > 0;
 	}
-
 	/**
 	 * @param string|int $key
-	 * @return bool
-	 */
-	public function hasMetaValue($key) {
-		return isset($this->meta[$key]);
-	}
-
-	/**
-	 * @param string|int $key
-	 * @param string $metaValue
+	 * @param string|null $metaValue
 	 * @return $this
 	 */
-	public function addMetaValue($key, $metaValue) {
+	public function addMetaValue($key, ?string $metaValue) {
 		if (!isset($this->meta)) {
 			$this->meta = [];
 		}

--- a/tests/test_app/src/Dto/MutableMetaDto.php
+++ b/tests/test_app/src/Dto/MutableMetaDto.php
@@ -129,8 +129,6 @@ class MutableMetaDto extends \CakeDto\Dto\AbstractDto {
 	 * @param string|int $key
 	 *
 	 * @return string|null
-	 *
-	 * @throws \RuntimeException If value with this key is not set.
 	 */
 	public function getMetaValue($key): ?string {
 		if (!isset($this->meta[$key])) {

--- a/tests/test_app/src/Dto/OldOneDto.php
+++ b/tests/test_app/src/Dto/OldOneDto.php
@@ -15,7 +15,7 @@ namespace TestApp\Dto;
  */
 class OldOneDto extends CarDto {
 
-	const FIELD_NAME = 'name';
+	public const FIELD_NAME = 'name';
 
 	/**
 	 * @var string|null
@@ -59,7 +59,7 @@ class OldOneDto extends CarDto {
 	 *
 	 * @return $this
 	 */
-	public function setName($name) {
+	public function setName(?string $name) {
 		$this->name = $name;
 		$this->_touchedFields[self::FIELD_NAME] = true;
 
@@ -69,7 +69,7 @@ class OldOneDto extends CarDto {
 	/**
 	 * @return string|null
 	 */
-	public function getName() {
+	public function getName(): ?string {
 		return $this->name;
 	}
 
@@ -78,7 +78,7 @@ class OldOneDto extends CarDto {
 	 *
 	 * @return string
 	 */
-	public function getNameOrFail() {
+	public function getNameOrFail(): string {
 		if (!isset($this->name)) {
 			throw new \RuntimeException('Value not set for field `name` (expected to be not null)');
 		}
@@ -89,7 +89,7 @@ class OldOneDto extends CarDto {
 	/**
 	 * @return bool
 	 */
-	public function hasName() {
+	public function hasName(): bool {
 		return $this->name !== null;
 	}
 

--- a/tests/test_app/src/Dto/OwnerDto.php
+++ b/tests/test_app/src/Dto/OwnerDto.php
@@ -14,8 +14,8 @@ namespace TestApp\Dto;
  */
 class OwnerDto extends \CakeDto\Dto\AbstractDto {
 
-	const FIELD_NAME = 'name';
-	const FIELD_BIRTH_YEAR = 'birthYear';
+	public const FIELD_NAME = 'name';
+	public const FIELD_BIRTH_YEAR = 'birthYear';
 
 	/**
 	 * @var string|null
@@ -78,7 +78,7 @@ class OwnerDto extends \CakeDto\Dto\AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setName($name) {
+	public function setName(?string $name) {
 		$this->name = $name;
 		$this->_touchedFields[self::FIELD_NAME] = true;
 
@@ -88,7 +88,7 @@ class OwnerDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @return string|null
 	 */
-	public function getName() {
+	public function getName(): ?string {
 		return $this->name;
 	}
 
@@ -97,7 +97,7 @@ class OwnerDto extends \CakeDto\Dto\AbstractDto {
 	 *
 	 * @return string
 	 */
-	public function getNameOrFail() {
+	public function getNameOrFail(): string {
 		if (!isset($this->name)) {
 			throw new \RuntimeException('Value not set for field `name` (expected to be not null)');
 		}
@@ -108,7 +108,7 @@ class OwnerDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @return bool
 	 */
-	public function hasName() {
+	public function hasName(): bool {
 		return $this->name !== null;
 	}
 
@@ -117,7 +117,7 @@ class OwnerDto extends \CakeDto\Dto\AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setBirthYear($birthYear) {
+	public function setBirthYear(?int $birthYear) {
 		$this->birthYear = $birthYear;
 		$this->_touchedFields[self::FIELD_BIRTH_YEAR] = true;
 
@@ -127,7 +127,7 @@ class OwnerDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @return int|null
 	 */
-	public function getBirthYear() {
+	public function getBirthYear(): ?int {
 		return $this->birthYear;
 	}
 
@@ -136,7 +136,7 @@ class OwnerDto extends \CakeDto\Dto\AbstractDto {
 	 *
 	 * @return int
 	 */
-	public function getBirthYearOrFail() {
+	public function getBirthYearOrFail(): int {
 		if (!isset($this->birthYear)) {
 			throw new \RuntimeException('Value not set for field `birthYear` (expected to be not null)');
 		}
@@ -147,7 +147,7 @@ class OwnerDto extends \CakeDto\Dto\AbstractDto {
 	/**
 	 * @return bool
 	 */
-	public function hasBirthYear() {
+	public function hasBirthYear(): bool {
 		return $this->birthYear !== null;
 	}
 

--- a/tests/test_app/src/Dto/PageDto.php
+++ b/tests/test_app/src/Dto/PageDto.php
@@ -14,8 +14,8 @@ namespace TestApp\Dto;
  */
 class PageDto extends \CakeDto\Dto\AbstractImmutableDto {
 
-	const FIELD_NUMBER = 'number';
-	const FIELD_CONTENT = 'content';
+	public const FIELD_NUMBER = 'number';
+	public const FIELD_CONTENT = 'content';
 
 	/**
 	 * @var int
@@ -78,7 +78,7 @@ class PageDto extends \CakeDto\Dto\AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withNumber($number) {
+	public function withNumber(int $number) {
 		$new = clone $this;
 		$new->number = $number;
 		$new->_touchedFields[self::FIELD_NUMBER] = true;
@@ -89,14 +89,14 @@ class PageDto extends \CakeDto\Dto\AbstractImmutableDto {
 	/**
 	 * @return int
 	 */
-	public function getNumber() {
+	public function getNumber(): int {
 		return $this->number;
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function hasNumber() {
+	public function hasNumber(): bool {
 		return $this->number !== null;
 	}
 
@@ -105,7 +105,7 @@ class PageDto extends \CakeDto\Dto\AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withContent($content) {
+	public function withContent(?string $content = null) {
 		$new = clone $this;
 		$new->content = $content;
 		$new->_touchedFields[self::FIELD_CONTENT] = true;
@@ -116,7 +116,7 @@ class PageDto extends \CakeDto\Dto\AbstractImmutableDto {
 	/**
 	 * @return string|null
 	 */
-	public function getContent() {
+	public function getContent(): ?string {
 		return $this->content;
 	}
 
@@ -125,7 +125,7 @@ class PageDto extends \CakeDto\Dto\AbstractImmutableDto {
 	 *
 	 * @return string
 	 */
-	public function getContentOrFail() {
+	public function getContentOrFail(): string {
 		if (!isset($this->content)) {
 			throw new \RuntimeException('Value not set for field `content` (expected to be not null)');
 		}
@@ -136,7 +136,7 @@ class PageDto extends \CakeDto\Dto\AbstractImmutableDto {
 	/**
 	 * @return bool
 	 */
-	public function hasContent() {
+	public function hasContent(): bool {
 		return $this->content !== null;
 	}
 

--- a/tests/test_app/src/Dto/TagDto.php
+++ b/tests/test_app/src/Dto/TagDto.php
@@ -15,9 +15,9 @@ namespace TestApp\Dto;
  */
 class TagDto extends \CakeDto\Dto\AbstractImmutableDto {
 
-	const FIELD_ID = 'id';
-	const FIELD_NAME = 'name';
-	const FIELD_WEIGHT = 'weight';
+	public const FIELD_ID = 'id';
+	public const FIELD_NAME = 'name';
+	public const FIELD_WEIGHT = 'weight';
 
 	/**
 	 * @var int
@@ -99,7 +99,7 @@ class TagDto extends \CakeDto\Dto\AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withId($id) {
+	public function withId(int $id) {
 		$new = clone $this;
 		$new->id = $id;
 		$new->_touchedFields[self::FIELD_ID] = true;
@@ -110,14 +110,14 @@ class TagDto extends \CakeDto\Dto\AbstractImmutableDto {
 	/**
 	 * @return int
 	 */
-	public function getId() {
+	public function getId(): int {
 		return $this->id;
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function hasId() {
+	public function hasId(): bool {
 		return $this->id !== null;
 	}
 
@@ -126,7 +126,7 @@ class TagDto extends \CakeDto\Dto\AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withName($name) {
+	public function withName(string $name) {
 		$new = clone $this;
 		$new->name = $name;
 		$new->_touchedFields[self::FIELD_NAME] = true;
@@ -137,14 +137,14 @@ class TagDto extends \CakeDto\Dto\AbstractImmutableDto {
 	/**
 	 * @return string
 	 */
-	public function getName() {
+	public function getName(): string {
 		return $this->name;
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function hasName() {
+	public function hasName(): bool {
 		return $this->name !== null;
 	}
 
@@ -153,7 +153,7 @@ class TagDto extends \CakeDto\Dto\AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withWeight($weight) {
+	public function withWeight(int $weight) {
 		$new = clone $this;
 		$new->weight = $weight;
 		$new->_touchedFields[self::FIELD_WEIGHT] = true;
@@ -164,7 +164,7 @@ class TagDto extends \CakeDto\Dto\AbstractImmutableDto {
 	/**
 	 * @return int
 	 */
-	public function getWeight() {
+	public function getWeight(): int {
 		return $this->weight;
 	}
 

--- a/tests/test_app/src/Dto/TransactionDto.php
+++ b/tests/test_app/src/Dto/TransactionDto.php
@@ -16,10 +16,10 @@ namespace TestApp\Dto;
  */
 class TransactionDto extends \CakeDto\Dto\AbstractImmutableDto {
 
-	const FIELD_CUSTOMER_ACCOUNT = 'customerAccount';
-	const FIELD_VALUE = 'value';
-	const FIELD_COMMENT = 'comment';
-	const FIELD_CREATED = 'created';
+	public const FIELD_CUSTOMER_ACCOUNT = 'customerAccount';
+	public const FIELD_VALUE = 'value';
+	public const FIELD_COMMENT = 'comment';
+	public const FIELD_CREATED = 'created';
 
 	/**
 	 * @var \TestApp\Dto\CustomerAccountDto
@@ -132,14 +132,14 @@ class TransactionDto extends \CakeDto\Dto\AbstractImmutableDto {
 	/**
 	 * @return \TestApp\Dto\CustomerAccountDto
 	 */
-	public function getCustomerAccount() {
+	public function getCustomerAccount(): \TestApp\Dto\CustomerAccountDto {
 		return $this->customerAccount;
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function hasCustomerAccount() {
+	public function hasCustomerAccount(): bool {
 		return $this->customerAccount !== null;
 	}
 
@@ -148,7 +148,7 @@ class TransactionDto extends \CakeDto\Dto\AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withValue($value) {
+	public function withValue(float $value) {
 		$new = clone $this;
 		$new->value = $value;
 		$new->_touchedFields[self::FIELD_VALUE] = true;
@@ -159,14 +159,14 @@ class TransactionDto extends \CakeDto\Dto\AbstractImmutableDto {
 	/**
 	 * @return float
 	 */
-	public function getValue() {
+	public function getValue(): float {
 		return $this->value;
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function hasValue() {
+	public function hasValue(): bool {
 		return $this->value !== null;
 	}
 
@@ -175,7 +175,7 @@ class TransactionDto extends \CakeDto\Dto\AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withComment($comment) {
+	public function withComment(?string $comment = null) {
 		$new = clone $this;
 		$new->comment = $comment;
 		$new->_touchedFields[self::FIELD_COMMENT] = true;
@@ -186,7 +186,7 @@ class TransactionDto extends \CakeDto\Dto\AbstractImmutableDto {
 	/**
 	 * @return string|null
 	 */
-	public function getComment() {
+	public function getComment(): ?string {
 		return $this->comment;
 	}
 
@@ -195,7 +195,7 @@ class TransactionDto extends \CakeDto\Dto\AbstractImmutableDto {
 	 *
 	 * @return string
 	 */
-	public function getCommentOrFail() {
+	public function getCommentOrFail(): string {
 		if (!isset($this->comment)) {
 			throw new \RuntimeException('Value not set for field `comment` (expected to be not null)');
 		}
@@ -206,7 +206,7 @@ class TransactionDto extends \CakeDto\Dto\AbstractImmutableDto {
 	/**
 	 * @return bool
 	 */
-	public function hasComment() {
+	public function hasComment(): bool {
 		return $this->comment !== null;
 	}
 
@@ -226,14 +226,14 @@ class TransactionDto extends \CakeDto\Dto\AbstractImmutableDto {
 	/**
 	 * @return \Cake\I18n\FrozenDate
 	 */
-	public function getCreated() {
+	public function getCreated(): \Cake\I18n\FrozenDate {
 		return $this->created;
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function hasCreated() {
+	public function hasCreated(): bool {
 		return $this->created !== null;
 	}
 


### PR DESCRIPTION
also set scalarTypeHints to true now with PHP7.2+
```xml
<field name="assocs" singular="assoc" type="int[]" associative="true"/>
<field name="nullableAssocs" singular="nullableAssoc" type="?int[]" associative="true"/>
```

The ? prefix makes the singular `int|null`

@asaliev what do you think?