### PR TITLE
`finder` config option is ignored

### DIFF
--- a/src/Generator/Builder.php
+++ b/src/Generator/Builder.php
@@ -82,6 +82,7 @@ class Builder {
 			'defaultCollectionType' => Configure::read('CakeDto.defaultCollectionType', '\ArrayObject'),
 			'debug' => (bool)Configure::read('CakeDto.debug'),
 			'immutable' => (bool)Configure::read('CakeDto.immutable'),
+			'finder' => Configure::read('CakeDto.finder', Finder::class),
 		];
 		$this->setConfig($config);
 	}
@@ -752,9 +753,9 @@ class Builder {
 	}
 
 	/**
-	 * @return \CakeDto\Generator\Finder
+	 * @return \CakeDto\Generator\FinderInterface
 	 */
-	protected function _finder(): Finder {
+	protected function _finder(): FinderInterface {
 		/** @phpstan-var class-string<\CakeDto\Generator\Finder> $finderClass */
 		$finderClass = $this->_config['finder'];
 

--- a/src/Generator/Finder.php
+++ b/src/Generator/Finder.php
@@ -5,7 +5,7 @@ namespace CakeDto\Generator;
 use DirectoryIterator;
 use InvalidArgumentException;
 
-class Finder {
+class Finder implements FinderInterface {
 
 	/**
 	 * @param string $configPath

--- a/src/Generator/FinderInterface.php
+++ b/src/Generator/FinderInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace CakeDto\Generator;
+
+interface FinderInterface
+{
+	/**
+	 * Find dto specification files
+	 *
+	 * Should return an array of file paths
+	 *
+	 * @param string $configPath
+	 * @param string $extension
+	 * @return array<string>
+	 */
+	public function collect(string $configPath, string $extension): array;
+}

--- a/src/Generator/FinderInterface.php
+++ b/src/Generator/FinderInterface.php
@@ -2,8 +2,8 @@
 
 namespace CakeDto\Generator;
 
-interface FinderInterface
-{
+interface FinderInterface {
+
 	/**
 	 * Find dto specification files
 	 *
@@ -14,4 +14,5 @@ interface FinderInterface
 	 * @return array<string>
 	 */
 	public function collect(string $configPath, string $extension): array;
+	
 }


### PR DESCRIPTION
The `finder` config is provided but not used. This commit allows developers to implement their own finder based on an interface.