### PR TITLE
Duplicate methods with nested dto's

### DIFF
--- a/src/Generator/FinderInterface.php
+++ b/src/Generator/FinderInterface.php
@@ -14,5 +14,5 @@ interface FinderInterface {
 	 * @return array<string>
 	 */
 	public function collect(string $configPath, string $extension): array;
-	
+
 }

--- a/templates/Dto/element/method_add.twig
+++ b/templates/Dto/element/method_add.twig
@@ -10,7 +10,7 @@
 	 * @param {% if singularType %}{{ singularType }}{% else %}mixed{% endif %}{% if singularNullable %}|null{% endif %} ${{ singular }}
 	 * @return $this
 	 */
-	public function add{{ singular[:1]|upper ~ singular[1:] }}({% if associative %}$key, {% endif %}{% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }}) {
+	public function add{{ name[:1]|upper ~ name[1:] }}({% if associative %}$key, {% endif %}{% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }}) {
 		if ($this->{{ name }} === null) {
 			$this->{{ name }} = {% if collectionType == 'array' %}[]{% else %}new {{ typeHint }}([]){% endif %};
 		}

--- a/templates/Dto/element/method_add_cake_collection.twig
+++ b/templates/Dto/element/method_add_cake_collection.twig
@@ -8,7 +8,7 @@
 	 *
 	 * @return $this
 	 */
-	public function add{{ singular[:1]|upper ~ singular[1:] }}({% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }}) {
+	public function add{{ name[:1]|upper ~ name[1:] }}({% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }}) {
 		if ($this->{{ name }} === null) {
 			$this->{{ name }} = new {{ typeHint }}([]);
 		}

--- a/templates/Dto/element/method_with_added.twig
+++ b/templates/Dto/element/method_with_added.twig
@@ -10,7 +10,7 @@
 	 * @param {{ singularType }}{% if singularNullable %}|null{% endif %} ${{ singular }}
 	 * @return static
 	 */
-	public function withAdded{{ singular[:1]|upper ~ singular[1:] }}({% if associative %}$key, {% endif %}{% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }}) {
+	public function withAdded{{ name[:1]|upper ~ name[1:] }}({% if associative %}$key, {% endif %}{% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }}) {
 		$new = clone $this;
 
 		if ($new->{{ name }} === null) {

--- a/templates/Dto/element/method_with_added_cake_collection.twig
+++ b/templates/Dto/element/method_with_added_cake_collection.twig
@@ -10,7 +10,7 @@
 	 * @param {{ singularType }}{% if singularNullable %}|null{% endif %} ${{ singular }}
 	 * @return static
 	 */
-	public function withAdded{{ singular[:1]|upper ~ singular[1:] }}({% if associative %}$key, {% endif %}{% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }}) {
+	public function withAdded{{ name[:1]|upper ~ name[1:] }}({% if associative %}$key, {% endif %}{% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }}) {
 		$new = clone $this;
 
 		if ($new->{{ name }} === null) {


### PR DESCRIPTION
When dto's of the same type are nested more than once in another dto, duplicate method names get generated since the dto class name is used but the property name should be used.