### PR TITLE
Relax spec filename requirements

### DIFF
--- a/src/Generator/Finder.php
+++ b/src/Generator/Finder.php
@@ -3,14 +3,12 @@
 namespace CakeDto\Generator;
 
 use DirectoryIterator;
-use InvalidArgumentException;
 
 class Finder implements FinderInterface {
 
 	/**
 	 * @param string $configPath
 	 * @param string $extension
-	 * @throws \InvalidArgumentException
 	 * @return array<string>
 	 */
 	public function collect(string $configPath, string $extension): array {
@@ -18,15 +16,10 @@ class Finder implements FinderInterface {
 		if (is_dir($configPath . 'dto')) {
 			$iterator = new DirectoryIterator($configPath . 'dto');
 			foreach ($iterator as $fileInfo) {
-				if ($fileInfo->isDot()) {
+				if ($fileInfo->isDot() || $fileInfo->getExtension() !== $extension) {
 					continue;
 				}
-
-				$file = $fileInfo->getPathname();
-				if (!preg_match('/^\w+\.dto\.' . $extension . '$/', $fileInfo->getFilename())) {
-					throw new InvalidArgumentException('Invalid config file name: ' . $fileInfo->getFilename());
-				}
-				$files[] = $file;
+				$files[] = $fileInfo->getPathname();
 			}
 		}
 		if (file_exists($configPath . 'dto.' . $extension)) {


### PR DESCRIPTION
I don't see any reason for forcing filename requirements other than the extension.
Since we are only scanning the `dto` folder, it should not contain any other files with that extension than specifications.

In the future i even think relaxing the configPath should be an option, hardcoded forcing the `dto` folder seems unnecessary when the path to scan is easily configurable.