### PR TITLE
allow int as float type fix for immutables

### DIFF
--- a/src/Dto/Dto.php
+++ b/src/Dto/Dto.php
@@ -744,6 +744,10 @@ abstract class Dto implements Serializable {
 		$actualType = $this->type($value);
 		$types = ['bool', 'int', 'string', 'double'];
 
+		if ($expectedType === 'float' && in_array($actualType, ['float', 'int'], true)) {
+			return;
+		}
+
 		if (in_array($expectedType, $types, true) || in_array($actualType, $types, true)) {
 			if ($actualType === $expectedType) {
 				return;

--- a/tests/TestCase/Dto/DtoTest.php
+++ b/tests/TestCase/Dto/DtoTest.php
@@ -6,6 +6,7 @@ use ArrayObject;
 use Cake\I18n\FrozenDate;
 use Cake\I18n\FrozenTime;
 use Cake\TestSuite\TestCase;
+use Exception;
 use InvalidArgumentException;
 use RuntimeException;
 use TestApp\Dto\ArticleDto;
@@ -501,7 +502,7 @@ class DtoTest extends TestCase {
 
 		$dto = new TransactionDto($array);
 
-		$this->assertSame(floatval($array[CarDto::FIELD_VALUE]), $dto->getValue());
+		$this->assertSame((float)($array[CarDto::FIELD_VALUE]), $dto->getValue());
 	}
 
 	/**
@@ -518,7 +519,7 @@ class DtoTest extends TestCase {
 			TransactionDto::FIELD_CREATED => FrozenDate::now(),
 		];
 
-		$e = new \Exception();
+		$e = new Exception();
 
 		try {
 			new TransactionDto($array);
@@ -529,4 +530,5 @@ class DtoTest extends TestCase {
 		$this->assertInstanceOf(InvalidArgumentException::class, $e);
 		$this->assertSame($e->getMessage(), 'Type of field `value` is `string`, expected `float`.');
 	}
+
 }

--- a/tests/TestCase/Dto/DtoTest.php
+++ b/tests/TestCase/Dto/DtoTest.php
@@ -3,6 +3,7 @@
 namespace CakeDto\Test\TestCase\Dto;
 
 use ArrayObject;
+use Cake\I18n\FrozenDate;
 use Cake\I18n\FrozenTime;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
@@ -11,8 +12,10 @@ use TestApp\Dto\ArticleDto;
 use TestApp\Dto\AuthorDto;
 use TestApp\Dto\CarDto;
 use TestApp\Dto\CarsDto;
+use TestApp\Dto\CustomerAccountDto;
 use TestApp\Dto\FlyingCarDto;
 use TestApp\Dto\OwnerDto;
+use TestApp\Dto\TransactionDto;
 use TestApp\Model\Entity\Article;
 use TestApp\Model\Entity\Author;
 use TestApp\ValueObject\Paint;
@@ -482,4 +485,45 @@ class DtoTest extends TestCase {
 		$this->assertNull($greenOrNull);
 	}
 
+	/**
+	 * @return void
+	 */
+	public function testAssertTypeIntAsFloatOnImmutable() {
+		$customerAccount = CustomerAccountDto::create([
+			CustomerAccountDto::FIELD_CUSTOMER_NAME => 'sample name',
+		]);
+
+		$array = [
+			TransactionDto::FIELD_VALUE => 33,
+			TransactionDto::FIELD_CUSTOMER_ACCOUNT => $customerAccount,
+			TransactionDto::FIELD_CREATED => FrozenDate::now(),
+		];
+
+		$dto = new TransactionDto($array);
+
+		$this->assertSame(floatval($array[CarDto::FIELD_VALUE]), $dto->getValue());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAssertTypeStringAsFloatOnImmutable() {
+		$customerAccount = CustomerAccountDto::create([
+			CustomerAccountDto::FIELD_CUSTOMER_NAME => 'sample name',
+		]);
+
+		$array = [
+			TransactionDto::FIELD_VALUE => '33.0',
+			TransactionDto::FIELD_CUSTOMER_ACCOUNT => $customerAccount,
+			TransactionDto::FIELD_CREATED => FrozenDate::now(),
+		];
+
+		try {
+			new TransactionDto($array);
+		} catch (InvalidArgumentException $e) {
+
+		}
+
+		$this->assertSame($e->getMessage(), 'Type of field `value` is `string`, expected `float`.');
+	}
 }

--- a/tests/TestCase/Dto/DtoTest.php
+++ b/tests/TestCase/Dto/DtoTest.php
@@ -518,12 +518,15 @@ class DtoTest extends TestCase {
 			TransactionDto::FIELD_CREATED => FrozenDate::now(),
 		];
 
+		$e = new \Exception();
+
 		try {
 			new TransactionDto($array);
 		} catch (InvalidArgumentException $e) {
 
 		}
 
+		$this->assertInstanceOf(InvalidArgumentException::class, $e);
 		$this->assertSame($e->getMessage(), 'Type of field `value` is `string`, expected `float`.');
 	}
 }


### PR DESCRIPTION
When using `json_encode` in PHP, we can preserve a float as float thanks to the `JSON_PRESERVE_ZERO_FRACTION` flag. But since not all programming languages have this implementation, passing a `float` as 1 instead of 1.0 makes filling/creating the dto from an array fail when using immutables. For immutables created from an array, variables are never set through their setters but rather directly. This validates the use of typechecking, but in this specific case, an int should be allowed to be set as float since this would also work for setters.