### PR TITLE
Fix empty arrayobject to array

### DIFF
--- a/src/Dto/Dto.php
+++ b/src/Dto/Dto.php
@@ -185,7 +185,7 @@ abstract class Dto implements Serializable {
 			if (is_object($value)) {
 				if ($value instanceof self) {
 					$values[$key] = $touched ? $value->touchedToArray($type) : $value->toArray($type);
-				} elseif ($value instanceof Countable && $value->count()) {
+				} elseif ($value instanceof Countable) {
 					$values = $this->transformCollectionToArray($value, $values, $key, $touched ? 'touchedToArray' : 'toArray', $type);
 				} elseif ($this->_metadata[$field]['serialize']) {
 					$values[$key] = $this->transformSerialized($value, $this->_metadata[$field]['serialize']);
@@ -219,6 +219,12 @@ abstract class Dto implements Serializable {
 	 * @return array
 	 */
 	protected function transformCollectionToArray($value, array $values, string $arrayKey, string $childConvertMethodName, string $type): array {
+		if ($value->count() === 0) {
+			$values[$arrayKey] = [];
+
+			return $values;
+		}
+
 		foreach ($value as $elementKey => $arrayElement) {
 			if (is_array($arrayElement) || is_scalar($arrayElement)) {
 				$values[$arrayKey][$elementKey] = $arrayElement;

--- a/tests/TestCase/Dto/DtoTest.php
+++ b/tests/TestCase/Dto/DtoTest.php
@@ -123,6 +123,23 @@ class DtoTest extends TestCase {
 	/**
 	 * @return void
 	 */
+	public function testToArrayEmptyArrayObject() {
+		$dto = new CarsDto();
+		$dto->setCars(new ArrayObject());
+
+		$result = $dto->toArray();
+		$expected = [
+			'cars' => [],
+		];
+
+		ksort($expected);
+		ksort($result);
+		$this->assertSame($expected, $result);
+	}
+
+	/**
+	 * @return void
+	 */
 	public function testToArrayDashed() {
 		$dto = new CarDto();
 		$dto->setDistanceTravelled(11);


### PR DESCRIPTION
When converting a DTO with a property which is an empty ArrayObject, it won't be converted to an array but stays as ArrayObject. When encoded to json, this result in `{}` as property value, rather than `[]` as you would expect.