### PR TITLE
Extend from any dto compatible class

### DIFF
--- a/src/Generator/Builder.php
+++ b/src/Generator/Builder.php
@@ -12,6 +12,7 @@ use CakeDto\Engine\EngineInterface;
 use InvalidArgumentException;
 use JsonSerializable;
 use ReflectionClass;
+use ReflectionException;
 use RuntimeException;
 
 class Builder {
@@ -161,7 +162,7 @@ class Builder {
 			} else {
 				try {
 					$extendedDtoReflectionClass = new ReflectionClass($extendedDto);
-				} catch (\ReflectionException $e) {
+				} catch (ReflectionException $e) {
 					throw new InvalidArgumentException(sprintf('Invalid %s DTO attribute `extends`: `%s`. Class does not seem to exist.', $dto['name'], $dto['extends']));
 				}
 

--- a/tests/TestCase/Generator/BuilderTest.php
+++ b/tests/TestCase/Generator/BuilderTest.php
@@ -7,10 +7,10 @@ use Cake\TestSuite\TestCase;
 use CakeDto\Engine\EngineInterface;
 use CakeDto\Engine\XmlEngine;
 use CakeDto\Generator\Builder;
-use CakeDto\Test\test_app\src\Dto\DummyNonDtoClass;
 use InvalidArgumentException;
 use TestApp\Dto\AuthorDto;
 use TestApp\Dto\CarDto;
+use TestApp\Dto\DummyNonDtoClass;
 use TestApp\TestSuite\AssociativeArrayTestTrait;
 
 class BuilderTest extends TestCase {
@@ -623,7 +623,7 @@ class BuilderTest extends TestCase {
 		$this->builder->expects($this->any())->method('_merge')->willReturn($result);
 
 		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessage('Invalid FlyingCar DTO attribute `extends`: `CakeDto\Test\test_app\src\Dto\DummyNonDtoClass`. Parent class should extend `CakeDto\Dto\AbstractDto`.');
+		$this->expectExceptionMessage('Invalid FlyingCar DTO attribute `extends`: `TestApp\Dto\DummyNonDtoClass`. Parent class should extend `CakeDto\Dto\AbstractDto`.');
 
 		$this->builder->build(TMP);
 	}

--- a/tests/TestCase/Generator/BuilderTest.php
+++ b/tests/TestCase/Generator/BuilderTest.php
@@ -623,7 +623,7 @@ class BuilderTest extends TestCase {
 		$this->builder->expects($this->any())->method('_merge')->willReturn($result);
 
 		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessage('Invalid FlyingCar DTO attribute `extends`: `CakeDto\Test\TestCase\Generator\DummyNonDtoClass`. Parent class should extend `CakeDto\Dto\AbstractDto`.');
+		$this->expectExceptionMessage('Invalid FlyingCar DTO attribute `extends`: `CakeDto\Test\test_app\src\Dto\DummyNonDtoClass`. Parent class should extend `CakeDto\Dto\AbstractDto`.');
 
 		$this->builder->build(TMP);
 	}

--- a/tests/test_app/src/Dto/DummyNonDtoClass.php
+++ b/tests/test_app/src/Dto/DummyNonDtoClass.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace CakeDto\Test\test_app\src\Dto;
+namespace TestApp\Dto;
 
 class DummyNonDtoClass
 {}

--- a/tests/test_app/src/Dto/DummyNonDtoClass.php
+++ b/tests/test_app/src/Dto/DummyNonDtoClass.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+
+namespace CakeDto\Test\test_app\src\Dto;
+
+class DummyNonDtoClass
+{}


### PR DESCRIPTION
This makes it possible to extend from any DTO compatible class.
This allow to split DTO definitions in multiple files and extend from earlier generated DTO's.