### PR TITLE
Add new Enum support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
 	"require": {
 		"php": ">=8.1",
 		"ext-json": "*",
-		"cakephp/cakephp": "^5.0.0",
+		"cakephp/cakephp": "^5.0.3",
 		"cakephp/twig-view": "^2.0.1",
 		"sebastian/diff": "^5.0.0"
 	},

--- a/docs/README.md
+++ b/docs/README.md
@@ -124,6 +124,7 @@ Simple array types:
 Concrete objects:
 - DTOs (without suffix)
 - Value objects and custom classes using FQCN and leading `\`.
+- Enums (mainly int/string backed enums)
 
 For all of the above you will have setters and getters available.
 

--- a/docs/examples/enum.dto.xml
+++ b/docs/examples/enum.dto.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<dtos
+	xmlns="cakephp-dto"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="cakephp-dto https://github.com/dereuromark/cakephp-dto">
+
+	<dto name="EnumTest" immutable="true">
+		<field name="someUnit" type="\TestApp\Model\Enum\MyUnit"/>
+		<field name="someStringBacked" type="\TestApp\Model\Enum\MyStringBacked"/>
+		<field name="someIntBacked" type="\TestApp\Model\Enum\MyIntBacked"/>
+	</dto>
+
+</dtos>

--- a/src/Dto/Dto.php
+++ b/src/Dto/Dto.php
@@ -878,7 +878,7 @@ abstract class Dto implements Serializable {
 		if ($this->_metadata[$field]['enum'] === 'unit') {
 			assert(is_string($value));
 
-			return $class::{$value};
+			return constant($class . "::{$value}");
 		}
 
 		/** @var class-string<\BackedEnum> $class */

--- a/src/Dto/Dto.php
+++ b/src/Dto/Dto.php
@@ -12,6 +12,7 @@ use Countable;
 use InvalidArgumentException;
 use RuntimeException;
 use Serializable;
+use UnitEnum;
 
 abstract class Dto implements Serializable {
 
@@ -197,6 +198,9 @@ abstract class Dto implements Serializable {
 					$values = $this->transformCollectionToArray($value, $values, $key, $touched ? 'touchedToArray' : 'toArray', $type);
 				} elseif ($this->_metadata[$field]['serialize']) {
 					$values[$key] = $this->transformSerialized($value, $this->_metadata[$field]['serialize']);
+				} elseif (!empty($this->_metadata[$field]['enum']) && $this->_metadata[$field]['enum'] === 'unit') {
+					assert($value instanceof UnitEnum);
+					$values[$key] = $this->transformEnum($value);
 				} else {
 					$values[$key] = $value;
 				}
@@ -319,6 +323,9 @@ abstract class Dto implements Serializable {
 				$value = $this->createObject($field, $value);
 			} elseif ($this->_metadata[$field]['factory']) {
 				$value = $this->createWithFactory($field, $value);
+			} elseif (!empty($this->_metadata[$field]['isClass']) && !empty($this->_metadata[$field]['enum'])) {
+				/** @var class-string<\BackedEnum|\UnitEnum> $field */
+				$value = $this->createEnum($field, $value);
 			} elseif (!empty($this->_metadata[$field]['isClass']) && !is_object($value)) {
 				$value = $this->createWithConstructor($field, $value);
 			}
@@ -848,6 +855,47 @@ abstract class Dto implements Serializable {
 	 */
 	public function __unserialize(array $data): void {
 		$this->setFromArray($data, true);
+	}
+
+	/**
+	 * @param class-string<\BackedEnum|\UnitEnum> $field
+	 * @param \BackedEnum|\UnitEnum|string|int|null $value
+	 *
+	 * @return \BackedEnum|\UnitEnum|null
+	 */
+	protected function createEnum(string $field, $value) {
+		if ($value === null) {
+			return null;
+		}
+
+		if ($value instanceof UnitEnum) {
+			return $value;
+		}
+
+		/** @var class-string<\BackedEnum|\UnitEnum> $class */
+		$class = $this->_metadata[$field]['type'];
+
+		if ($this->_metadata[$field]['enum'] === 'unit') {
+			assert(is_string($value));
+
+			return $class::{$value};
+		}
+
+		/** @var class-string<\BackedEnum> $class */
+		return $class::tryFrom($value);
+	}
+
+	/**
+	 * @param \UnitEnum|null $value
+	 *
+	 * @return string|null
+	 */
+	protected function transformEnum(?UnitEnum $value): ?string {
+		if ($value === null) {
+			return null;
+		}
+
+		return $value->name;
 	}
 
 }

--- a/src/Generator/Builder.php
+++ b/src/Generator/Builder.php
@@ -12,6 +12,7 @@ use CakeDto\Engine\EngineInterface;
 use InvalidArgumentException;
 use JsonSerializable;
 use ReflectionClass;
+use ReflectionEnum;
 use ReflectionException;
 use RuntimeException;
 
@@ -61,6 +62,7 @@ class Builder {
 		'name',
 		'type',
 		'isClass',
+		'enum',
 		'serialize',
 		'factory',
 		'required',
@@ -374,6 +376,8 @@ class Builder {
 					$fields[$key]['serialize'] = $this->detectSerialize($fields[$key]);
 				}
 
+				$fields[$key]['enum'] = $this->enumType($field['type']);
+
 				continue;
 			}
 
@@ -605,6 +609,27 @@ class Builder {
 		}
 
 		return interface_exists($type) || class_exists($type);
+	}
+
+	/**
+	 * @param class-string<\BackedEnum|\UnitEnum> $type
+	 *
+	 * @return string|null
+	 */
+	protected function enumType(string $type): ?string {
+		try {
+			$reflectionEnum = new ReflectionEnum($type);
+		} catch (ReflectionException $e) {
+			return null;
+		}
+
+		if (!$reflectionEnum->isBacked()) {
+			return 'unit';
+		}
+
+		$namedType = (string)$reflectionEnum->getBackingType();
+
+		return $namedType;
 	}
 
 	/**

--- a/tests/TestCase/Dto/EnumTest.php
+++ b/tests/TestCase/Dto/EnumTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace CakeDto\Test\TestCase\Dto;
+
+use Cake\TestSuite\TestCase;
+use TestApp\Dto\EnumTestDto;
+use TestApp\Model\Enum\MyIntBacked;
+use TestApp\Model\Enum\MyStringBacked;
+use TestApp\Model\Enum\MyUnit;
+
+class EnumTest extends TestCase {
+
+	/**
+	 * @return void
+	 */
+	public function testEnums() {
+		$array = [
+			EnumTestDto::FIELD_SOME_UNIT => MyUnit::Y,
+			EnumTestDto::FIELD_SOME_STRING_BACKED => MyStringBacked::Bar,
+			EnumTestDto::FIELD_SOME_INT_BACKED => MyIntBacked::Foo,
+		];
+		$dto = new EnumTestDto($array);
+
+		$newArray = $dto->toArray();
+
+		// Apparently unit enums dont work otherwise
+		$array[EnumTestDto::FIELD_SOME_UNIT] = 'Y';
+		$this->assertSame($array, $newArray);
+
+		$serialized = $dto->serialize();
+		$expected = '{"someUnit":"Y","someStringBacked":"b","someIntBacked":1}';
+		$this->assertSame($expected, $serialized);
+
+		$dto = EnumTestDto::fromUnserialized($serialized);
+		$this->assertSame($array, $dto->toArray());
+	}
+
+}

--- a/tests/TestCase/Generator/BuilderTest.php
+++ b/tests/TestCase/Generator/BuilderTest.php
@@ -623,7 +623,7 @@ class BuilderTest extends TestCase {
 		$this->builder->expects($this->any())->method('_merge')->willReturn($result);
 
 		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessage('Invalid FlyingCar DTO attribute `extends`: `TestApp\Dto\DummyNonDtoClass`. Parent class should extend `CakeDto\Dto\AbstractDto`.');
+		$this->expectExceptionMessage('Invalid FlyingCar DTO attribute `extends`: `TestApp\Dto\DummyNonDtoClass`. Class does not seem to exist.');
 
 		$this->builder->build(TMP);
 	}
@@ -789,6 +789,7 @@ class BuilderTest extends TestCase {
 			'isArray' => false,
 			'isClass' => true,
 			'dto' => null,
+			'enum' => null,
 			'collection' => false,
 			'collectionType' => null,
 			'key' => null,
@@ -811,6 +812,7 @@ class BuilderTest extends TestCase {
 			'isArray' => false,
 			'isClass' => true,
 			'dto' => null,
+			'enum' => null,
 			'collection' => false,
 			'collectionType' => null,
 			'key' => null,
@@ -833,6 +835,7 @@ class BuilderTest extends TestCase {
 			'isArray' => false,
 			'isClass' => true,
 			'dto' => null,
+			'enum' => null,
 			'collection' => false,
 			'collectionType' => null,
 			'key' => null,

--- a/tests/TestCase/Generator/BuilderTest.php
+++ b/tests/TestCase/Generator/BuilderTest.php
@@ -10,7 +10,7 @@ use CakeDto\Generator\Builder;
 use InvalidArgumentException;
 use TestApp\Dto\AuthorDto;
 use TestApp\Dto\CarDto;
-use TestApp\Dto\DummyNonDtoClass;
+use TestApp\DtoCustom\DummyNonDtoClass;
 use TestApp\TestSuite\AssociativeArrayTestTrait;
 
 class BuilderTest extends TestCase {
@@ -623,7 +623,7 @@ class BuilderTest extends TestCase {
 		$this->builder->expects($this->any())->method('_merge')->willReturn($result);
 
 		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessage('Invalid FlyingCar DTO attribute `extends`: `TestApp\Dto\DummyNonDtoClass`. Class does not seem to exist.');
+		$this->expectExceptionMessage('Invalid FlyingCar DTO attribute `extends`: `TestApp\DtoCustom\DummyNonDtoClass`. Parent class should extend `CakeDto\Dto\AbstractDto`.');
 
 		$this->builder->build(TMP);
 	}

--- a/tests/generate.php
+++ b/tests/generate.php
@@ -47,6 +47,7 @@ $xmls = [
 	'immutable.dto.xml',
 	'orm.dto.xml',
 	'cake_collection.dto.xml',
+	'enum.dto.xml',
 ];
 foreach ($xmls as $xml) {
 	$xmlPath = ROOT . DS . 'docs/examples/' . $xml;

--- a/tests/test_app/src/Dto/ArticleDto.php
+++ b/tests/test_app/src/Dto/ArticleDto.php
@@ -109,6 +109,7 @@ class ArticleDto extends \CakeDto\Dto\AbstractImmutableDto {
 			'serialize' => null,
 			'factory' => null,
 			'isClass' => true,
+			'enum' => null,
 		],
 		'tags' => [
 			'name' => 'tags',

--- a/tests/test_app/src/Dto/CarDto.php
+++ b/tests/test_app/src/Dto/CarDto.php
@@ -80,6 +80,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 			'serialize' => 'FromArrayToArray',
 			'factory' => null,
 			'isClass' => true,
+			'enum' => null,
 		],
 		'isNew' => [
 			'name' => 'isNew',
@@ -141,6 +142,7 @@ class CarDto extends \CakeDto\Dto\AbstractDto {
 			'serialize' => null,
 			'factory' => null,
 			'isClass' => true,
+			'enum' => null,
 		],
 		'owner' => [
 			'name' => 'owner',

--- a/tests/test_app/src/Dto/CustomerAccountDto.php
+++ b/tests/test_app/src/Dto/CustomerAccountDto.php
@@ -76,6 +76,7 @@ class CustomerAccountDto extends \CakeDto\Dto\AbstractDto {
 			'serialize' => null,
 			'factory' => null,
 			'isClass' => true,
+			'enum' => null,
 		],
 	];
 

--- a/tests/test_app/src/Dto/DummyNonDtoClass.php
+++ b/tests/test_app/src/Dto/DummyNonDtoClass.php
@@ -1,7 +1,0 @@
-<?php
-declare(strict_types=1);
-
-namespace TestApp\Dto;
-
-class DummyNonDtoClass
-{}

--- a/tests/test_app/src/Dto/EnumTestDto.php
+++ b/tests/test_app/src/Dto/EnumTestDto.php
@@ -1,0 +1,265 @@
+<?php declare(strict_types=1);
+/**
+ * !!! Auto generated file. Do not directly modify this file. !!!
+ * You can either version control this or generate the file on the fly prior to usage/deployment.
+ */
+
+namespace TestApp\Dto;
+
+/**
+ * EnumTest DTO
+ *
+ * @property \TestApp\Model\Enum\MyUnit|null $someUnit
+ * @property \TestApp\Model\Enum\MyStringBacked|null $someStringBacked
+ * @property \TestApp\Model\Enum\MyIntBacked|null $someIntBacked
+ */
+class EnumTestDto extends \CakeDto\Dto\AbstractImmutableDto {
+
+	public const FIELD_SOME_UNIT = 'someUnit';
+	public const FIELD_SOME_STRING_BACKED = 'someStringBacked';
+	public const FIELD_SOME_INT_BACKED = 'someIntBacked';
+
+	/**
+	 * @var \TestApp\Model\Enum\MyUnit|null
+	 */
+	protected $someUnit;
+
+	/**
+	 * @var \TestApp\Model\Enum\MyStringBacked|null
+	 */
+	protected $someStringBacked;
+
+	/**
+	 * @var \TestApp\Model\Enum\MyIntBacked|null
+	 */
+	protected $someIntBacked;
+
+	/**
+	 * Some data is only for debugging for now.
+	 *
+	 * @var array<string, array<string, mixed>>
+	 */
+	protected array $_metadata = [
+		'someUnit' => [
+			'name' => 'someUnit',
+			'type' => '\TestApp\Model\Enum\MyUnit',
+			'required' => false,
+			'defaultValue' => null,
+			'dto' => null,
+			'collectionType' => null,
+			'associative' => false,
+			'key' => null,
+			'serialize' => null,
+			'factory' => null,
+			'isClass' => true,
+			'enum' => 'unit',
+		],
+		'someStringBacked' => [
+			'name' => 'someStringBacked',
+			'type' => '\TestApp\Model\Enum\MyStringBacked',
+			'required' => false,
+			'defaultValue' => null,
+			'dto' => null,
+			'collectionType' => null,
+			'associative' => false,
+			'key' => null,
+			'serialize' => null,
+			'factory' => null,
+			'isClass' => true,
+			'enum' => 'string',
+		],
+		'someIntBacked' => [
+			'name' => 'someIntBacked',
+			'type' => '\TestApp\Model\Enum\MyIntBacked',
+			'required' => false,
+			'defaultValue' => null,
+			'dto' => null,
+			'collectionType' => null,
+			'associative' => false,
+			'key' => null,
+			'serialize' => null,
+			'factory' => null,
+			'isClass' => true,
+			'enum' => 'int',
+		],
+	];
+
+	/**
+	* @var array<string, array<string, string>>
+	*/
+	protected array $_keyMap = [
+		'underscored' => [
+			'some_unit' => 'someUnit',
+			'some_string_backed' => 'someStringBacked',
+			'some_int_backed' => 'someIntBacked',
+		],
+		'dashed' => [
+			'some-unit' => 'someUnit',
+			'some-string-backed' => 'someStringBacked',
+			'some-int-backed' => 'someIntBacked',
+		],
+	];
+
+	/**
+	 * @param \TestApp\Model\Enum\MyUnit|null $someUnit
+	 *
+	 * @return static
+	 */
+	public function withSomeUnit(?\TestApp\Model\Enum\MyUnit $someUnit = null) {
+		$new = clone $this;
+		$new->someUnit = $someUnit;
+		$new->_touchedFields[self::FIELD_SOME_UNIT] = true;
+
+		return $new;
+	}
+
+	/**
+	 * @param \TestApp\Model\Enum\MyUnit $someUnit
+	 *
+	 * @throws \RuntimeException If value is not present.
+	 *
+	 * @return $this
+	 */
+	public function setSomeUnitOrFail(\TestApp\Model\Enum\MyUnit $someUnit) {
+		$this->someUnit = $someUnit;
+		$this->_touchedFields[self::FIELD_SOME_UNIT] = true;
+
+		return $this;
+	}
+
+	/**
+	 * @return \TestApp\Model\Enum\MyUnit|null
+	 */
+	public function getSomeUnit(): ?\TestApp\Model\Enum\MyUnit {
+		return $this->someUnit;
+	}
+
+	/**
+	 * @throws \RuntimeException If value is not set.
+	 *
+	 * @return \TestApp\Model\Enum\MyUnit
+	 */
+	public function getSomeUnitOrFail(): \TestApp\Model\Enum\MyUnit {
+		if ($this->someUnit === null) {
+			throw new \RuntimeException('Value not set for field `someUnit` (expected to be not null)');
+		}
+
+		return $this->someUnit;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function hasSomeUnit(): bool {
+		return $this->someUnit !== null;
+	}
+
+	/**
+	 * @param \TestApp\Model\Enum\MyStringBacked|null $someStringBacked
+	 *
+	 * @return static
+	 */
+	public function withSomeStringBacked(?\TestApp\Model\Enum\MyStringBacked $someStringBacked = null) {
+		$new = clone $this;
+		$new->someStringBacked = $someStringBacked;
+		$new->_touchedFields[self::FIELD_SOME_STRING_BACKED] = true;
+
+		return $new;
+	}
+
+	/**
+	 * @param \TestApp\Model\Enum\MyStringBacked $someStringBacked
+	 *
+	 * @throws \RuntimeException If value is not present.
+	 *
+	 * @return $this
+	 */
+	public function setSomeStringBackedOrFail(\TestApp\Model\Enum\MyStringBacked $someStringBacked) {
+		$this->someStringBacked = $someStringBacked;
+		$this->_touchedFields[self::FIELD_SOME_STRING_BACKED] = true;
+
+		return $this;
+	}
+
+	/**
+	 * @return \TestApp\Model\Enum\MyStringBacked|null
+	 */
+	public function getSomeStringBacked(): ?\TestApp\Model\Enum\MyStringBacked {
+		return $this->someStringBacked;
+	}
+
+	/**
+	 * @throws \RuntimeException If value is not set.
+	 *
+	 * @return \TestApp\Model\Enum\MyStringBacked
+	 */
+	public function getSomeStringBackedOrFail(): \TestApp\Model\Enum\MyStringBacked {
+		if ($this->someStringBacked === null) {
+			throw new \RuntimeException('Value not set for field `someStringBacked` (expected to be not null)');
+		}
+
+		return $this->someStringBacked;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function hasSomeStringBacked(): bool {
+		return $this->someStringBacked !== null;
+	}
+
+	/**
+	 * @param \TestApp\Model\Enum\MyIntBacked|null $someIntBacked
+	 *
+	 * @return static
+	 */
+	public function withSomeIntBacked(?\TestApp\Model\Enum\MyIntBacked $someIntBacked = null) {
+		$new = clone $this;
+		$new->someIntBacked = $someIntBacked;
+		$new->_touchedFields[self::FIELD_SOME_INT_BACKED] = true;
+
+		return $new;
+	}
+
+	/**
+	 * @param \TestApp\Model\Enum\MyIntBacked $someIntBacked
+	 *
+	 * @throws \RuntimeException If value is not present.
+	 *
+	 * @return $this
+	 */
+	public function setSomeIntBackedOrFail(\TestApp\Model\Enum\MyIntBacked $someIntBacked) {
+		$this->someIntBacked = $someIntBacked;
+		$this->_touchedFields[self::FIELD_SOME_INT_BACKED] = true;
+
+		return $this;
+	}
+
+	/**
+	 * @return \TestApp\Model\Enum\MyIntBacked|null
+	 */
+	public function getSomeIntBacked(): ?\TestApp\Model\Enum\MyIntBacked {
+		return $this->someIntBacked;
+	}
+
+	/**
+	 * @throws \RuntimeException If value is not set.
+	 *
+	 * @return \TestApp\Model\Enum\MyIntBacked
+	 */
+	public function getSomeIntBackedOrFail(): \TestApp\Model\Enum\MyIntBacked {
+		if ($this->someIntBacked === null) {
+			throw new \RuntimeException('Value not set for field `someIntBacked` (expected to be not null)');
+		}
+
+		return $this->someIntBacked;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function hasSomeIntBacked(): bool {
+		return $this->someIntBacked !== null;
+	}
+
+}

--- a/tests/test_app/src/Dto/OwnerDto.php
+++ b/tests/test_app/src/Dto/OwnerDto.php
@@ -83,6 +83,7 @@ class OwnerDto extends \CakeDto\Dto\AbstractDto {
 			'serialize' => 'array',
 			'factory' => null,
 			'isClass' => true,
+			'enum' => null,
 		],
 		'birthday' => [
 			'name' => 'birthday',
@@ -96,6 +97,7 @@ class OwnerDto extends \CakeDto\Dto\AbstractDto {
 			'serialize' => null,
 			'factory' => null,
 			'isClass' => true,
+			'enum' => null,
 		],
 	];
 

--- a/tests/test_app/src/Dto/TransactionDto.php
+++ b/tests/test_app/src/Dto/TransactionDto.php
@@ -95,6 +95,7 @@ class TransactionDto extends \CakeDto\Dto\AbstractImmutableDto {
 			'serialize' => null,
 			'factory' => null,
 			'isClass' => true,
+			'enum' => null,
 		],
 	];
 

--- a/tests/test_app/src/DtoCustom/DummyNonDtoClass.php
+++ b/tests/test_app/src/DtoCustom/DummyNonDtoClass.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace TestApp\DtoCustom;
+
+class DummyNonDtoClass {
+}

--- a/tests/test_app/src/Model/Enum/MyIntBacked.php
+++ b/tests/test_app/src/Model/Enum/MyIntBacked.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Model\Enum;
+
+use Cake\Database\Type\EnumLabelInterface;
+use Cake\Utility\Inflector;
+
+enum MyIntBacked: int implements EnumLabelInterface
+{
+	case Foo = 1;
+	case Bar = 0;
+
+	/**
+	 * @return string
+	 */
+	public function label(): string {
+		return Inflector::humanize(Inflector::underscore($this->name));
+	}
+}

--- a/tests/test_app/src/Model/Enum/MyStringBacked.php
+++ b/tests/test_app/src/Model/Enum/MyStringBacked.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Model\Enum;
+
+use Cake\Database\Type\EnumLabelInterface;
+use Cake\Utility\Inflector;
+
+/**
+ * StringB Enum
+ */
+enum MyStringBacked: string implements EnumLabelInterface
+{
+	case Foo = 'f';
+	case Bar = 'b';
+
+	/**
+	 * @return string
+	 */
+	public function label(): string {
+		return Inflector::humanize(Inflector::underscore($this->name));
+	}
+}

--- a/tests/test_app/src/Model/Enum/MyUnit.php
+++ b/tests/test_app/src/Model/Enum/MyUnit.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Model\Enum;
+
+enum MyUnit
+{
+	case X;
+	case Y;
+}


### PR DESCRIPTION
Following https://www.dereuromark.de/2024/01/30/enums-in-cakephp-reloaded/

Apparently, serialize/json_encode doesnt work with Unit enums, they need to be pre-converted to their string value.
Thats far from ideal.