### PR TITLE
Improve code quality and configuration

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd">
 	<php>
 		<ini name="memory_limit" value="-1"/>
 		<ini name="apc.enable_cli" value="1"/>

--- a/src/Dto/Dto.php
+++ b/src/Dto/Dto.php
@@ -199,7 +199,9 @@ abstract class Dto implements Serializable {
 				} elseif ($this->_metadata[$field]['serialize']) {
 					$values[$key] = $this->transformSerialized($value, $this->_metadata[$field]['serialize']);
 				} elseif (!empty($this->_metadata[$field]['enum']) && $this->_metadata[$field]['enum'] === 'unit') {
-					assert($value instanceof UnitEnum);
+					if (!$value instanceof UnitEnum) {
+						throw new InvalidArgumentException('Expected UnitEnum instance');
+					}
 					$values[$key] = $this->transformEnum($value);
 				} else {
 					$values[$key] = $value;

--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -91,7 +91,7 @@ class Generator {
 			$target = $srcPath . 'Dto' . DS . $name . Configure::read('CakeDto.suffix', 'Dto') . '.php';
 			$targetPath = dirname($target);
 			if (!is_dir($targetPath)) {
-				mkdir($targetPath, 0700, true);
+				mkdir($targetPath, 0755, true);
 			}
 
 			if ($isModified) {
@@ -134,7 +134,7 @@ class Generator {
 	 */
 	protected function findExistingDtos(string $path): array {
 		if (!is_dir($path)) {
-			mkdir($path, 0700, true);
+			mkdir($path, 0755, true);
 		}
 
 		$files = [];


### PR DESCRIPTION
## Summary

This PR addresses several code quality and configuration improvements:

1. **PHPUnit XML Schema Update (Issue #8)**: Updated schema reference from version 9.5 to 11.0 to align with composer.json requirement of PHPUnit 10.5+

2. **Directory Permissions Fix (Issue #3)**: Changed mkdir permissions from 0700 to 0755 in Generator.php for better web server compatibility. The restrictive 0700 permissions could prevent web servers from accessing generated files.

3. **Runtime Check for Production Safety (Issue #14)**: Replaced `assert($value instanceof UnitEnum)` with proper runtime check in Dto.php. Assert statements can be disabled in production with `zend.assertions=-1`, making this a potential source of bugs.

## Changes

- `phpunit.xml.dist`: Updated schema URL to match PHPUnit version
- `src/Generator/Generator.php`: Fixed directory permissions in 2 locations (lines 94, 137)
- `src/Dto/Dto.php`: Replaced assert with InvalidArgumentException throw

## Testing

All quality checks pass:
- ✅ PHPUnit: 88 tests, 1892 assertions
- ✅ PHPStan Level 8: No errors
- ✅ PHPCS: Clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)