### PR TITLE
Add backward-compatible aliases for AbstractDto classes

### DIFF
--- a/src/Dto/AbstractDto.php
+++ b/src/Dto/AbstractDto.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CakeDto\Dto;
+
+use PhpCollective\Dto\Dto\AbstractDto as BaseAbstractDto;
+
+/**
+ * Backward-compatible alias for AbstractDto.
+ *
+ * @deprecated Use \PhpCollective\Dto\Dto\AbstractDto instead.
+ */
+abstract class AbstractDto extends BaseAbstractDto {
+}

--- a/src/Dto/AbstractImmutableDto.php
+++ b/src/Dto/AbstractImmutableDto.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CakeDto\Dto;
+
+use PhpCollective\Dto\Dto\AbstractImmutableDto as BaseAbstractImmutableDto;
+
+/**
+ * Backward-compatible alias for AbstractImmutableDto.
+ *
+ * @deprecated Use \PhpCollective\Dto\Dto\AbstractImmutableDto instead.
+ */
+abstract class AbstractImmutableDto extends BaseAbstractImmutableDto {
+}


### PR DESCRIPTION
## Summary

- Provides `CakeDto\Dto\AbstractDto` as a deprecated alias for `\PhpCollective\Dto\Dto\AbstractDto`
- Provides `CakeDto\Dto\AbstractImmutableDto` as a deprecated alias for `\PhpCollective\Dto\Dto\AbstractImmutableDto`

This maintains backward compatibility for packages like cakephp-statemachine that depend on the old namespace after the refactoring in #77.

## Test plan

- [x] All existing tests pass
- [x] PHPCS passes
- [ ] Verify cakephp-sandbox tests pass with this change