### PR TITLE
Use @var type assertion instead of @phpstan-ignore

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,3 +20,4 @@ parameters:
 			path: tests/test_app/src/Dto/*Dto.php
 	# Generated test DTOs may have unmatched ignores (e.g., empty DTOs)
 	reportUnmatchedIgnoredErrors: false
+

--- a/templates/Dto/element/array_shape.twig
+++ b/templates/Dto/element/array_shape.twig
@@ -1,5 +1,4 @@
 {% if arrayShape %}
-
 	/**
 	 * @param string|null $type
 	 * @param array<string>|null $fields
@@ -8,8 +7,10 @@
 	 * @return {{ arrayShape|raw }}
 	 */
 	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array {
-		/** @phpstan-ignore return.type */
-		return $this->_toArrayInternal($type, $fields, $touched);
+		/** @var {{ arrayShape|raw }} $result */
+		$result = $this->_toArrayInternal($type, $fields, $touched);
+
+		return $result;
 	}
 
 	/**
@@ -19,7 +20,7 @@
 	 *
 	 * @return static
 	 */
-	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static { // @phpstan-ignore method.childParameterType
+	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static {
 		return static::_createFromArrayInternal($data, $ignoreMissing, $type);
 	}
 {% endif %}

--- a/tests/files/TreeDto/methods.txt
+++ b/tests/files/TreeDto/methods.txt
@@ -64,7 +64,6 @@
 		return $this->size !== null;
 	}
 
-
 	/**
 	 * @param string|null $type
 	 * @param array<string>|null $fields
@@ -73,8 +72,10 @@
 	 * @return array{type: string|null, size: int|null}
 	 */
 	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array {
-		/** @phpstan-ignore return.type */
-		return $this->_toArrayInternal($type, $fields, $touched);
+		/** @var array{type: string|null, size: int|null} $result */
+		$result = $this->_toArrayInternal($type, $fields, $touched);
+
+		return $result;
 	}
 
 	/**
@@ -84,7 +85,7 @@
 	 *
 	 * @return static
 	 */
-	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static { // @phpstan-ignore method.childParameterType
+	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static {
 		return static::_createFromArrayInternal($data, $ignoreMissing, $type);
 	}
 

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/BaseDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/BaseDto.php
@@ -298,7 +298,6 @@ class BaseDto extends AbstractDto {
 		return $this->repo !== null;
 	}
 
-
 	/**
 	 * @param string|null $type
 	 * @param array<string>|null $fields
@@ -307,8 +306,10 @@ class BaseDto extends AbstractDto {
 	 * @return array{ref: string, sha: string, user: array<string, mixed>, repo: array<string, mixed>}
 	 */
 	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array {
-		/** @phpstan-ignore return.type */
-		return $this->_toArrayInternal($type, $fields, $touched);
+		/** @var array{ref: string, sha: string, user: array<string, mixed>, repo: array<string, mixed>} $result */
+		$result = $this->_toArrayInternal($type, $fields, $touched);
+
+		return $result;
 	}
 
 	/**
@@ -318,7 +319,7 @@ class BaseDto extends AbstractDto {
 	 *
 	 * @return static
 	 */
-	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static { // @phpstan-ignore method.childParameterType
+	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static {
 		return static::_createFromArrayInternal($data, $ignoreMissing, $type);
 	}
 

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/HeadDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/HeadDto.php
@@ -298,7 +298,6 @@ class HeadDto extends AbstractDto {
 		return $this->repo !== null;
 	}
 
-
 	/**
 	 * @param string|null $type
 	 * @param array<string>|null $fields
@@ -307,8 +306,10 @@ class HeadDto extends AbstractDto {
 	 * @return array{ref: string, sha: string, user: array<string, mixed>, repo: array<string, mixed>}
 	 */
 	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array {
-		/** @phpstan-ignore return.type */
-		return $this->_toArrayInternal($type, $fields, $touched);
+		/** @var array{ref: string, sha: string, user: array<string, mixed>, repo: array<string, mixed>} $result */
+		$result = $this->_toArrayInternal($type, $fields, $touched);
+
+		return $result;
 	}
 
 	/**
@@ -318,7 +319,7 @@ class HeadDto extends AbstractDto {
 	 *
 	 * @return static
 	 */
-	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static { // @phpstan-ignore method.childParameterType
+	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static {
 		return static::_createFromArrayInternal($data, $ignoreMissing, $type);
 	}
 

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/LabelDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/LabelDto.php
@@ -224,7 +224,6 @@ class LabelDto extends AbstractDto {
 		return $this->color !== null;
 	}
 
-
 	/**
 	 * @param string|null $type
 	 * @param array<string>|null $fields
@@ -233,8 +232,10 @@ class LabelDto extends AbstractDto {
 	 * @return array{name: string|null, color: string|null}
 	 */
 	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array {
-		/** @phpstan-ignore return.type */
-		return $this->_toArrayInternal($type, $fields, $touched);
+		/** @var array{name: string|null, color: string|null} $result */
+		$result = $this->_toArrayInternal($type, $fields, $touched);
+
+		return $result;
 	}
 
 	/**
@@ -244,7 +245,7 @@ class LabelDto extends AbstractDto {
 	 *
 	 * @return static
 	 */
-	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static { // @phpstan-ignore method.childParameterType
+	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static {
 		return static::_createFromArrayInternal($data, $ignoreMissing, $type);
 	}
 

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/PullRequestDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/PullRequestDto.php
@@ -725,7 +725,6 @@ class PullRequestDto extends AbstractDto {
 		return $this->base !== null;
 	}
 
-
 	/**
 	 * @param string|null $type
 	 * @param array<string>|null $fields
@@ -734,8 +733,10 @@ class PullRequestDto extends AbstractDto {
 	 * @return array{url: string, number: int, state: string, title: string, body: string, user: array<string, mixed>, createdAt: string, labels: array<string, \Sandbox\Dto\Github\LabelDto>, head: array<string, mixed>|null, base: array<string, mixed>|null}
 	 */
 	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array {
-		/** @phpstan-ignore return.type */
-		return $this->_toArrayInternal($type, $fields, $touched);
+		/** @var array{url: string, number: int, state: string, title: string, body: string, user: array<string, mixed>, createdAt: string, labels: array<string, \Sandbox\Dto\Github\LabelDto>, head: array<string, mixed>|null, base: array<string, mixed>|null} $result */
+		$result = $this->_toArrayInternal($type, $fields, $touched);
+
+		return $result;
 	}
 
 	/**
@@ -745,7 +746,7 @@ class PullRequestDto extends AbstractDto {
 	 *
 	 * @return static
 	 */
-	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static { // @phpstan-ignore method.childParameterType
+	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static {
 		return static::_createFromArrayInternal($data, $ignoreMissing, $type);
 	}
 

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/RepoDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/RepoDto.php
@@ -298,7 +298,6 @@ class RepoDto extends AbstractDto {
 		return $this->owner !== null;
 	}
 
-
 	/**
 	 * @param string|null $type
 	 * @param array<string>|null $fields
@@ -307,8 +306,10 @@ class RepoDto extends AbstractDto {
 	 * @return array{name: string, htmlUrl: string, private: bool, owner: array<string, mixed>}
 	 */
 	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array {
-		/** @phpstan-ignore return.type */
-		return $this->_toArrayInternal($type, $fields, $touched);
+		/** @var array{name: string, htmlUrl: string, private: bool, owner: array<string, mixed>} $result */
+		$result = $this->_toArrayInternal($type, $fields, $touched);
+
+		return $result;
 	}
 
 	/**
@@ -318,7 +319,7 @@ class RepoDto extends AbstractDto {
 	 *
 	 * @return static
 	 */
-	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static { // @phpstan-ignore method.childParameterType
+	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static {
 		return static::_createFromArrayInternal($data, $ignoreMissing, $type);
 	}
 

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/UserDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/UserDto.php
@@ -242,7 +242,6 @@ class UserDto extends AbstractDto {
 		return $this->type !== null;
 	}
 
-
 	/**
 	 * @param string|null $type
 	 * @param array<string>|null $fields
@@ -251,8 +250,10 @@ class UserDto extends AbstractDto {
 	 * @return array{login: string, htmlUrl: string, type: string}
 	 */
 	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array {
-		/** @phpstan-ignore return.type */
-		return $this->_toArrayInternal($type, $fields, $touched);
+		/** @var array{login: string, htmlUrl: string, type: string} $result */
+		$result = $this->_toArrayInternal($type, $fields, $touched);
+
+		return $result;
 	}
 
 	/**
@@ -262,7 +263,7 @@ class UserDto extends AbstractDto {
 	 *
 	 * @return static
 	 */
-	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static { // @phpstan-ignore method.childParameterType
+	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static {
 		return static::_createFromArrayInternal($data, $ignoreMissing, $type);
 	}
 

--- a/tests/test_app/plugins/Sandbox/src/Dto/Jira/IssueDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Jira/IssueDto.php
@@ -432,7 +432,6 @@ class IssueDto extends AbstractDto {
 		return $this->version !== null;
 	}
 
-
 	/**
 	 * @param string|null $type
 	 * @param array<string>|null $fields
@@ -441,8 +440,10 @@ class IssueDto extends AbstractDto {
 	 * @return array{id: string, key: string, status: string, priority: string, summary: string, version: string|null}
 	 */
 	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array {
-		/** @phpstan-ignore return.type */
-		return $this->_toArrayInternal($type, $fields, $touched);
+		/** @var array{id: string, key: string, status: string, priority: string, summary: string, version: string|null} $result */
+		$result = $this->_toArrayInternal($type, $fields, $touched);
+
+		return $result;
 	}
 
 	/**
@@ -452,7 +453,7 @@ class IssueDto extends AbstractDto {
 	 *
 	 * @return static
 	 */
-	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static { // @phpstan-ignore method.childParameterType
+	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static {
 		return static::_createFromArrayInternal($data, $ignoreMissing, $type);
 	}
 

--- a/tests/test_app/src/Dto/ArticleDto.php
+++ b/tests/test_app/src/Dto/ArticleDto.php
@@ -491,7 +491,6 @@ class ArticleDto extends AbstractImmutableDto {
 		return $new;
 	}
 
-
 	/**
 	 * @param string|null $type
 	 * @param array<string>|null $fields
@@ -500,8 +499,10 @@ class ArticleDto extends AbstractImmutableDto {
 	 * @return array{id: int, author: array{id: int, name: string, email: string|null}, title: string, created: \Cake\I18n\Date, tags: array<int, array{id: int, name: string, weight: int}>, meta: array<string, string>}
 	 */
 	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array {
-		/** @phpstan-ignore return.type */
-		return $this->_toArrayInternal($type, $fields, $touched);
+		/** @var array{id: int, author: array{id: int, name: string, email: string|null}, title: string, created: \Cake\I18n\Date, tags: array<int, array{id: int, name: string, weight: int}>, meta: array<string, string>} $result */
+		$result = $this->_toArrayInternal($type, $fields, $touched);
+
+		return $result;
 	}
 
 	/**
@@ -511,7 +512,7 @@ class ArticleDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static { // @phpstan-ignore method.childParameterType
+	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static {
 		return static::_createFromArrayInternal($data, $ignoreMissing, $type);
 	}
 

--- a/tests/test_app/src/Dto/AuthorDto.php
+++ b/tests/test_app/src/Dto/AuthorDto.php
@@ -268,7 +268,6 @@ class AuthorDto extends AbstractImmutableDto {
 		return $this->email !== null;
 	}
 
-
 	/**
 	 * @param string|null $type
 	 * @param array<string>|null $fields
@@ -277,8 +276,10 @@ class AuthorDto extends AbstractImmutableDto {
 	 * @return array{id: int, name: string, email: string|null}
 	 */
 	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array {
-		/** @phpstan-ignore return.type */
-		return $this->_toArrayInternal($type, $fields, $touched);
+		/** @var array{id: int, name: string, email: string|null} $result */
+		$result = $this->_toArrayInternal($type, $fields, $touched);
+
+		return $result;
 	}
 
 	/**
@@ -288,7 +289,7 @@ class AuthorDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static { // @phpstan-ignore method.childParameterType
+	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static {
 		return static::_createFromArrayInternal($data, $ignoreMissing, $type);
 	}
 

--- a/tests/test_app/src/Dto/BookDto.php
+++ b/tests/test_app/src/Dto/BookDto.php
@@ -149,7 +149,6 @@ class BookDto extends AbstractImmutableDto {
 		return $new;
 	}
 
-
 	/**
 	 * @param string|null $type
 	 * @param array<string>|null $fields
@@ -158,8 +157,10 @@ class BookDto extends AbstractImmutableDto {
 	 * @return array{pages: array<int, array{number: int, content: string|null}>}
 	 */
 	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array {
-		/** @phpstan-ignore return.type */
-		return $this->_toArrayInternal($type, $fields, $touched);
+		/** @var array{pages: array<int, array{number: int, content: string|null}>} $result */
+		$result = $this->_toArrayInternal($type, $fields, $touched);
+
+		return $result;
 	}
 
 	/**
@@ -169,7 +170,7 @@ class BookDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static { // @phpstan-ignore method.childParameterType
+	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static {
 		return static::_createFromArrayInternal($data, $ignoreMissing, $type);
 	}
 

--- a/tests/test_app/src/Dto/CarDto.php
+++ b/tests/test_app/src/Dto/CarDto.php
@@ -618,7 +618,6 @@ class CarDto extends AbstractDto {
 		return $this->owner !== null;
 	}
 
-
 	/**
 	 * @param string|null $type
 	 * @param array<string>|null $fields
@@ -627,8 +626,10 @@ class CarDto extends AbstractDto {
 	 * @return array{color: \TestApp\ValueObject\Paint|null, isNew: bool|null, value: float|null, distanceTravelled: int|null, attributes: array<int, mixed>|null, manufactured: \Cake\I18n\Date|null, owner: array{name: string|null, insuranceProvider: string|null, attributes: \TestApp\ValueObject\KeyValuePair|null, birthday: \TestApp\ValueObject\Birthday|null}|null}
 	 */
 	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array {
-		/** @phpstan-ignore return.type */
-		return $this->_toArrayInternal($type, $fields, $touched);
+		/** @var array{color: \TestApp\ValueObject\Paint|null, isNew: bool|null, value: float|null, distanceTravelled: int|null, attributes: array<int, mixed>|null, manufactured: \Cake\I18n\Date|null, owner: array{name: string|null, insuranceProvider: string|null, attributes: \TestApp\ValueObject\KeyValuePair|null, birthday: \TestApp\ValueObject\Birthday|null}|null} $result */
+		$result = $this->_toArrayInternal($type, $fields, $touched);
+
+		return $result;
 	}
 
 	/**
@@ -638,7 +639,7 @@ class CarDto extends AbstractDto {
 	 *
 	 * @return static
 	 */
-	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static { // @phpstan-ignore method.childParameterType
+	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static {
 		return static::_createFromArrayInternal($data, $ignoreMissing, $type);
 	}
 

--- a/tests/test_app/src/Dto/CarsDto.php
+++ b/tests/test_app/src/Dto/CarsDto.php
@@ -171,7 +171,6 @@ class CarsDto extends AbstractDto {
 		return $this;
 	}
 
-
 	/**
 	 * @param string|null $type
 	 * @param array<string>|null $fields
@@ -180,8 +179,10 @@ class CarsDto extends AbstractDto {
 	 * @return array{cars: array<string, array{color: \TestApp\ValueObject\Paint|null, isNew: bool|null, value: float|null, distanceTravelled: int|null, attributes: array<int, mixed>|null, manufactured: \Cake\I18n\Date|null, owner: array{name: string|null, insuranceProvider: string|null, attributes: \TestApp\ValueObject\KeyValuePair|null, birthday: \TestApp\ValueObject\Birthday|null}|null}>}
 	 */
 	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array {
-		/** @phpstan-ignore return.type */
-		return $this->_toArrayInternal($type, $fields, $touched);
+		/** @var array{cars: array<string, array{color: \TestApp\ValueObject\Paint|null, isNew: bool|null, value: float|null, distanceTravelled: int|null, attributes: array<int, mixed>|null, manufactured: \Cake\I18n\Date|null, owner: array{name: string|null, insuranceProvider: string|null, attributes: \TestApp\ValueObject\KeyValuePair|null, birthday: \TestApp\ValueObject\Birthday|null}|null}>} $result */
+		$result = $this->_toArrayInternal($type, $fields, $touched);
+
+		return $result;
 	}
 
 	/**
@@ -191,7 +192,7 @@ class CarsDto extends AbstractDto {
 	 *
 	 * @return static
 	 */
-	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static { // @phpstan-ignore method.childParameterType
+	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static {
 		return static::_createFromArrayInternal($data, $ignoreMissing, $type);
 	}
 

--- a/tests/test_app/src/Dto/CustomerAccountDto.php
+++ b/tests/test_app/src/Dto/CustomerAccountDto.php
@@ -288,7 +288,6 @@ class CustomerAccountDto extends AbstractDto {
 		return $this->lastLogin !== null;
 	}
 
-
 	/**
 	 * @param string|null $type
 	 * @param array<string>|null $fields
@@ -297,8 +296,10 @@ class CustomerAccountDto extends AbstractDto {
 	 * @return array{customerName: string, birthYear: int|null, lastLogin: \Cake\I18n\DateTime|null}
 	 */
 	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array {
-		/** @phpstan-ignore return.type */
-		return $this->_toArrayInternal($type, $fields, $touched);
+		/** @var array{customerName: string, birthYear: int|null, lastLogin: \Cake\I18n\DateTime|null} $result */
+		$result = $this->_toArrayInternal($type, $fields, $touched);
+
+		return $result;
 	}
 
 	/**
@@ -308,7 +309,7 @@ class CustomerAccountDto extends AbstractDto {
 	 *
 	 * @return static
 	 */
-	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static { // @phpstan-ignore method.childParameterType
+	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static {
 		return static::_createFromArrayInternal($data, $ignoreMissing, $type);
 	}
 

--- a/tests/test_app/src/Dto/EmptyOneDto.php
+++ b/tests/test_app/src/Dto/EmptyOneDto.php
@@ -68,7 +68,6 @@ class EmptyOneDto extends AbstractDto {
 	}
 
 
-
 	/**
 	 * @param string|null $type
 	 * @param array<string>|null $fields
@@ -77,8 +76,10 @@ class EmptyOneDto extends AbstractDto {
 	 * @return array{}
 	 */
 	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array {
-		/** @phpstan-ignore return.type */
-		return $this->_toArrayInternal($type, $fields, $touched);
+		/** @var array{} $result */
+		$result = $this->_toArrayInternal($type, $fields, $touched);
+
+		return $result;
 	}
 
 	/**
@@ -88,7 +89,7 @@ class EmptyOneDto extends AbstractDto {
 	 *
 	 * @return static
 	 */
-	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static { // @phpstan-ignore method.childParameterType
+	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static {
 		return static::_createFromArrayInternal($data, $ignoreMissing, $type);
 	}
 

--- a/tests/test_app/src/Dto/EnumTestDto.php
+++ b/tests/test_app/src/Dto/EnumTestDto.php
@@ -314,7 +314,6 @@ class EnumTestDto extends AbstractImmutableDto {
 		return $this->someIntBacked !== null;
 	}
 
-
 	/**
 	 * @param string|null $type
 	 * @param array<string>|null $fields
@@ -323,8 +322,10 @@ class EnumTestDto extends AbstractImmutableDto {
 	 * @return array{someUnit: \TestApp\Model\Enum\MyUnit|null, someStringBacked: \TestApp\Model\Enum\MyStringBacked|null, someIntBacked: \TestApp\Model\Enum\MyIntBacked|null}
 	 */
 	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array {
-		/** @phpstan-ignore return.type */
-		return $this->_toArrayInternal($type, $fields, $touched);
+		/** @var array{someUnit: \TestApp\Model\Enum\MyUnit|null, someStringBacked: \TestApp\Model\Enum\MyStringBacked|null, someIntBacked: \TestApp\Model\Enum\MyIntBacked|null} $result */
+		$result = $this->_toArrayInternal($type, $fields, $touched);
+
+		return $result;
 	}
 
 	/**
@@ -334,7 +335,7 @@ class EnumTestDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static { // @phpstan-ignore method.childParameterType
+	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static {
 		return static::_createFromArrayInternal($data, $ignoreMissing, $type);
 	}
 

--- a/tests/test_app/src/Dto/FlyingCarDto.php
+++ b/tests/test_app/src/Dto/FlyingCarDto.php
@@ -257,7 +257,6 @@ class FlyingCarDto extends CarDto {
 		return $this->complexAttributes !== null;
 	}
 
-
 	/**
 	 * @param string|null $type
 	 * @param array<string>|null $fields
@@ -266,8 +265,10 @@ class FlyingCarDto extends CarDto {
 	 * @return array{maxAltitude: int, maxSpeed: int, complexAttributes: array<int, mixed>|null}
 	 */
 	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array {
-		/** @phpstan-ignore return.type */
-		return $this->_toArrayInternal($type, $fields, $touched);
+		/** @var array{maxAltitude: int, maxSpeed: int, complexAttributes: array<int, mixed>|null} $result */
+		$result = $this->_toArrayInternal($type, $fields, $touched);
+
+		return $result;
 	}
 
 	/**
@@ -277,7 +278,7 @@ class FlyingCarDto extends CarDto {
 	 *
 	 * @return static
 	 */
-	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static { // @phpstan-ignore method.childParameterType
+	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static {
 		return static::_createFromArrayInternal($data, $ignoreMissing, $type);
 	}
 

--- a/tests/test_app/src/Dto/MutableMetaDto.php
+++ b/tests/test_app/src/Dto/MutableMetaDto.php
@@ -222,7 +222,6 @@ class MutableMetaDto extends AbstractDto {
 		return $this;
 	}
 
-
 	/**
 	 * @param string|null $type
 	 * @param array<string>|null $fields
@@ -231,8 +230,10 @@ class MutableMetaDto extends AbstractDto {
 	 * @return array{title: string, meta: array<string, string>}
 	 */
 	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array {
-		/** @phpstan-ignore return.type */
-		return $this->_toArrayInternal($type, $fields, $touched);
+		/** @var array{title: string, meta: array<string, string>} $result */
+		$result = $this->_toArrayInternal($type, $fields, $touched);
+
+		return $result;
 	}
 
 	/**
@@ -242,7 +243,7 @@ class MutableMetaDto extends AbstractDto {
 	 *
 	 * @return static
 	 */
-	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static { // @phpstan-ignore method.childParameterType
+	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static {
 		return static::_createFromArrayInternal($data, $ignoreMissing, $type);
 	}
 

--- a/tests/test_app/src/Dto/OldOneDto.php
+++ b/tests/test_app/src/Dto/OldOneDto.php
@@ -147,7 +147,6 @@ class OldOneDto extends CarDto {
 		return $this->name !== null;
 	}
 
-
 	/**
 	 * @param string|null $type
 	 * @param array<string>|null $fields
@@ -156,8 +155,10 @@ class OldOneDto extends CarDto {
 	 * @return array{name: string|null}
 	 */
 	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array {
-		/** @phpstan-ignore return.type */
-		return $this->_toArrayInternal($type, $fields, $touched);
+		/** @var array{name: string|null} $result */
+		$result = $this->_toArrayInternal($type, $fields, $touched);
+
+		return $result;
 	}
 
 	/**
@@ -167,7 +168,7 @@ class OldOneDto extends CarDto {
 	 *
 	 * @return static
 	 */
-	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static { // @phpstan-ignore method.childParameterType
+	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static {
 		return static::_createFromArrayInternal($data, $ignoreMissing, $type);
 	}
 

--- a/tests/test_app/src/Dto/OwnerDto.php
+++ b/tests/test_app/src/Dto/OwnerDto.php
@@ -384,7 +384,6 @@ class OwnerDto extends AbstractDto {
 		return $this->birthday !== null;
 	}
 
-
 	/**
 	 * @param string|null $type
 	 * @param array<string>|null $fields
@@ -393,8 +392,10 @@ class OwnerDto extends AbstractDto {
 	 * @return array{name: string|null, insuranceProvider: string|null, attributes: \TestApp\ValueObject\KeyValuePair|null, birthday: \TestApp\ValueObject\Birthday|null}
 	 */
 	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array {
-		/** @phpstan-ignore return.type */
-		return $this->_toArrayInternal($type, $fields, $touched);
+		/** @var array{name: string|null, insuranceProvider: string|null, attributes: \TestApp\ValueObject\KeyValuePair|null, birthday: \TestApp\ValueObject\Birthday|null} $result */
+		$result = $this->_toArrayInternal($type, $fields, $touched);
+
+		return $result;
 	}
 
 	/**
@@ -404,7 +405,7 @@ class OwnerDto extends AbstractDto {
 	 *
 	 * @return static
 	 */
-	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static { // @phpstan-ignore method.childParameterType
+	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static {
 		return static::_createFromArrayInternal($data, $ignoreMissing, $type);
 	}
 

--- a/tests/test_app/src/Dto/PageDto.php
+++ b/tests/test_app/src/Dto/PageDto.php
@@ -211,7 +211,6 @@ class PageDto extends AbstractImmutableDto {
 		return $this->content !== null;
 	}
 
-
 	/**
 	 * @param string|null $type
 	 * @param array<string>|null $fields
@@ -220,8 +219,10 @@ class PageDto extends AbstractImmutableDto {
 	 * @return array{number: int, content: string|null}
 	 */
 	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array {
-		/** @phpstan-ignore return.type */
-		return $this->_toArrayInternal($type, $fields, $touched);
+		/** @var array{number: int, content: string|null} $result */
+		$result = $this->_toArrayInternal($type, $fields, $touched);
+
+		return $result;
 	}
 
 	/**
@@ -231,7 +232,7 @@ class PageDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static { // @phpstan-ignore method.childParameterType
+	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static {
 		return static::_createFromArrayInternal($data, $ignoreMissing, $type);
 	}
 

--- a/tests/test_app/src/Dto/TagDto.php
+++ b/tests/test_app/src/Dto/TagDto.php
@@ -242,7 +242,6 @@ class TagDto extends AbstractImmutableDto {
 	}
 
 
-
 	/**
 	 * @param string|null $type
 	 * @param array<string>|null $fields
@@ -251,8 +250,10 @@ class TagDto extends AbstractImmutableDto {
 	 * @return array{id: int, name: string, weight: int}
 	 */
 	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array {
-		/** @phpstan-ignore return.type */
-		return $this->_toArrayInternal($type, $fields, $touched);
+		/** @var array{id: int, name: string, weight: int} $result */
+		$result = $this->_toArrayInternal($type, $fields, $touched);
+
+		return $result;
 	}
 
 	/**
@@ -262,7 +263,7 @@ class TagDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static { // @phpstan-ignore method.childParameterType
+	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static {
 		return static::_createFromArrayInternal($data, $ignoreMissing, $type);
 	}
 

--- a/tests/test_app/src/Dto/TransactionDto.php
+++ b/tests/test_app/src/Dto/TransactionDto.php
@@ -327,7 +327,6 @@ class TransactionDto extends AbstractImmutableDto {
 		return $this->created !== null;
 	}
 
-
 	/**
 	 * @param string|null $type
 	 * @param array<string>|null $fields
@@ -336,8 +335,10 @@ class TransactionDto extends AbstractImmutableDto {
 	 * @return array{customerAccount: array{customerName: string, birthYear: int|null, lastLogin: \Cake\I18n\DateTime|null}, value: float, comment: string|null, created: \Cake\I18n\Date}
 	 */
 	public function toArray(?string $type = null, ?array $fields = null, bool $touched = false): array {
-		/** @phpstan-ignore return.type */
-		return $this->_toArrayInternal($type, $fields, $touched);
+		/** @var array{customerAccount: array{customerName: string, birthYear: int|null, lastLogin: \Cake\I18n\DateTime|null}, value: float, comment: string|null, created: \Cake\I18n\Date} $result */
+		$result = $this->_toArrayInternal($type, $fields, $touched);
+
+		return $result;
 	}
 
 	/**
@@ -347,7 +348,7 @@ class TransactionDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static { // @phpstan-ignore method.childParameterType
+	public static function createFromArray(array $data, bool $ignoreMissing = false, ?string $type = null): static {
 		return static::_createFromArrayInternal($data, $ignoreMissing, $type);
 	}
 


### PR DESCRIPTION
## Summary
- Align with php-collective/dto commit 435af7b
- Use intermediate variable with `@var` annotation for type assertion instead of `@phpstan-ignore`
- This is a cleaner approach that properly asserts the type rather than suppressing the error

## Changes
- Updated `array_shape.twig` template to use `@var` pattern
- Regenerated all test DTOs
- Updated TreeDto test fixture