### PR TITLE
Remove constructor overrides after parent library fix

### DIFF
--- a/src/Dto/AbstractDto.php
+++ b/src/Dto/AbstractDto.php
@@ -7,31 +7,9 @@ namespace CakeDto\Dto;
 use PhpCollective\Dto\Dto\AbstractDto as BaseAbstractDto;
 
 /**
- * CakePHP-specific AbstractDto with corrected fast path logic.
+ * Backward-compatible alias for AbstractDto.
  *
- * The fast path optimization is used only in lenient mode (ignoreMissing=true),
- * ensuring strict mode (!ignoreMissing) maintains full type validation.
+ * @deprecated Use \PhpCollective\Dto\Dto\AbstractDto instead.
  */
 abstract class AbstractDto extends BaseAbstractDto {
-
-	/**
-	 * @param array<string, mixed>|null $data
-	 * @param bool $ignoreMissing
-	 * @param string|null $type
-	 */
-	public function __construct(?array $data = null, bool $ignoreMissing = false, ?string $type = null) {
-		if ($data) {
-			// Use optimized fast path only when ignoreMissing is true (lenient mode)
-			// In strict mode (!$ignoreMissing), we need full type validation
-			if ($ignoreMissing && $type === null && method_exists($this, 'setFromArrayFast')) {
-				$this->setFromArrayFast($data);
-			} else {
-				$this->setFromArray($data, $ignoreMissing, $type);
-			}
-		}
-
-		$this->setDefaults();
-		$this->validate();
-	}
-
 }

--- a/src/Dto/AbstractImmutableDto.php
+++ b/src/Dto/AbstractImmutableDto.php
@@ -7,31 +7,9 @@ namespace CakeDto\Dto;
 use PhpCollective\Dto\Dto\AbstractImmutableDto as BaseAbstractImmutableDto;
 
 /**
- * CakePHP-specific AbstractImmutableDto with corrected fast path logic.
+ * Backward-compatible alias for AbstractImmutableDto.
  *
- * The fast path optimization is used only in lenient mode (ignoreMissing=true),
- * ensuring strict mode (!ignoreMissing) maintains full type validation.
+ * @deprecated Use \PhpCollective\Dto\Dto\AbstractImmutableDto instead.
  */
 abstract class AbstractImmutableDto extends BaseAbstractImmutableDto {
-
-	/**
-	 * @param array<string, mixed>|null $data
-	 * @param bool $ignoreMissing
-	 * @param string|null $type
-	 */
-	public function __construct(?array $data = null, bool $ignoreMissing = false, ?string $type = null) {
-		if ($data) {
-			// Use optimized fast path only when ignoreMissing is true (lenient mode)
-			// In strict mode (!$ignoreMissing), we need full type validation
-			if ($ignoreMissing && $type === null && method_exists($this, 'setFromArrayFast')) {
-				$this->setFromArrayFast($data);
-			} else {
-				$this->setFromArray($data, $ignoreMissing, $type);
-			}
-		}
-
-		$this->setDefaults();
-		$this->validate();
-	}
-
 }

--- a/src/Generator/Builder.php
+++ b/src/Generator/Builder.php
@@ -6,8 +6,6 @@ namespace CakeDto\Generator;
 
 use Cake\Core\Configure;
 use Cake\Core\InstanceConfigTrait;
-use CakeDto\Dto\AbstractDto;
-use CakeDto\Dto\AbstractImmutableDto;
 use PhpCollective\Dto\Engine\EngineInterface;
 use PhpCollective\Dto\Generator\Builder as BaseBuilder;
 
@@ -18,20 +16,6 @@ use PhpCollective\Dto\Generator\Builder as BaseBuilder;
  * configuration handling and namespace resolution.
  */
 class Builder extends BaseBuilder {
-
-	/**
-	 * Abstract DTO class for mutable DTOs.
-	 *
-	 * @var string
-	 */
-	public const ABSTRACT_DTO = '\\' . AbstractDto::class;
-
-	/**
-	 * Abstract DTO class for immutable DTOs.
-	 *
-	 * @var string
-	 */
-	public const ABSTRACT_IMMUTABLE_DTO = '\\' . AbstractImmutableDto::class;
 
 	use InstanceConfigTrait {
 		setConfig as traitSetConfig;
@@ -77,33 +61,6 @@ class Builder extends BaseBuilder {
 		}
 
 		return $this;
-	}
-
-	/**
-	 * Build DTOs from configuration.
-	 *
-	 * Overrides parent to use CakePHP-specific abstract classes with
-	 * corrected fast path logic for constructor.
-	 *
-	 * @param string $configPath
-	 * @param array<string, mixed> $options
-	 *
-	 * @return array<string, array<string, mixed>>
-	 */
-	public function build(string $configPath, array $options = []): array {
-		$result = parent::build($configPath, $options);
-
-		// Replace parent library's abstract classes with CakeDto wrapper classes
-		// which have corrected constructor logic for the fast path
-		foreach ($result as $name => $dto) {
-			if ($dto['extends'] === '\\PhpCollective\\Dto\\Dto\\AbstractDto') {
-				$result[$name]['extends'] = static::ABSTRACT_DTO;
-			} elseif ($dto['extends'] === '\\PhpCollective\\Dto\\Dto\\AbstractImmutableDto') {
-				$result[$name]['extends'] = static::ABSTRACT_IMMUTABLE_DTO;
-			}
-		}
-
-		return $result;
 	}
 
 	/**

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/BaseDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/BaseDto.php
@@ -6,7 +6,7 @@
 
 namespace Sandbox\Dto\Github;
 
-use CakeDto\Dto\AbstractDto;
+use PhpCollective\Dto\Dto\AbstractDto;
 
 /**
  * Github/Base DTO

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/HeadDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/HeadDto.php
@@ -6,7 +6,7 @@
 
 namespace Sandbox\Dto\Github;
 
-use CakeDto\Dto\AbstractDto;
+use PhpCollective\Dto\Dto\AbstractDto;
 
 /**
  * Github/Head DTO

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/LabelDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/LabelDto.php
@@ -6,7 +6,7 @@
 
 namespace Sandbox\Dto\Github;
 
-use CakeDto\Dto\AbstractDto;
+use PhpCollective\Dto\Dto\AbstractDto;
 
 /**
  * Github/Label DTO

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/PullRequestDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/PullRequestDto.php
@@ -6,7 +6,7 @@
 
 namespace Sandbox\Dto\Github;
 
-use CakeDto\Dto\AbstractDto;
+use PhpCollective\Dto\Dto\AbstractDto;
 
 /**
  * Github/PullRequest DTO

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/RepoDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/RepoDto.php
@@ -6,7 +6,7 @@
 
 namespace Sandbox\Dto\Github;
 
-use CakeDto\Dto\AbstractDto;
+use PhpCollective\Dto\Dto\AbstractDto;
 
 /**
  * Github/Repo DTO

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/UserDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/UserDto.php
@@ -6,7 +6,7 @@
 
 namespace Sandbox\Dto\Github;
 
-use CakeDto\Dto\AbstractDto;
+use PhpCollective\Dto\Dto\AbstractDto;
 
 /**
  * Github/User DTO

--- a/tests/test_app/plugins/Sandbox/src/Dto/Jira/IssueDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Jira/IssueDto.php
@@ -6,7 +6,7 @@
 
 namespace Sandbox\Dto\Jira;
 
-use CakeDto\Dto\AbstractDto;
+use PhpCollective\Dto\Dto\AbstractDto;
 
 /**
  * Jira/Issue DTO

--- a/tests/test_app/src/Dto/ArticleDto.php
+++ b/tests/test_app/src/Dto/ArticleDto.php
@@ -6,7 +6,7 @@
 
 namespace TestApp\Dto;
 
-use CakeDto\Dto\AbstractImmutableDto;
+use PhpCollective\Dto\Dto\AbstractImmutableDto;
 
 /**
  * Article DTO

--- a/tests/test_app/src/Dto/AuthorDto.php
+++ b/tests/test_app/src/Dto/AuthorDto.php
@@ -6,7 +6,7 @@
 
 namespace TestApp\Dto;
 
-use CakeDto\Dto\AbstractImmutableDto;
+use PhpCollective\Dto\Dto\AbstractImmutableDto;
 
 /**
  * Author DTO

--- a/tests/test_app/src/Dto/BookDto.php
+++ b/tests/test_app/src/Dto/BookDto.php
@@ -6,7 +6,7 @@
 
 namespace TestApp\Dto;
 
-use CakeDto\Dto\AbstractImmutableDto;
+use PhpCollective\Dto\Dto\AbstractImmutableDto;
 
 /**
  * Book DTO

--- a/tests/test_app/src/Dto/CarDto.php
+++ b/tests/test_app/src/Dto/CarDto.php
@@ -6,7 +6,7 @@
 
 namespace TestApp\Dto;
 
-use CakeDto\Dto\AbstractDto;
+use PhpCollective\Dto\Dto\AbstractDto;
 
 /**
  * Car DTO

--- a/tests/test_app/src/Dto/CarsDto.php
+++ b/tests/test_app/src/Dto/CarsDto.php
@@ -6,7 +6,7 @@
 
 namespace TestApp\Dto;
 
-use CakeDto\Dto\AbstractDto;
+use PhpCollective\Dto\Dto\AbstractDto;
 
 /**
  * Cars DTO

--- a/tests/test_app/src/Dto/CustomerAccountDto.php
+++ b/tests/test_app/src/Dto/CustomerAccountDto.php
@@ -6,7 +6,7 @@
 
 namespace TestApp\Dto;
 
-use CakeDto\Dto\AbstractDto;
+use PhpCollective\Dto\Dto\AbstractDto;
 
 /**
  * CustomerAccount DTO

--- a/tests/test_app/src/Dto/EmptyOneDto.php
+++ b/tests/test_app/src/Dto/EmptyOneDto.php
@@ -6,7 +6,7 @@
 
 namespace TestApp\Dto;
 
-use CakeDto\Dto\AbstractDto;
+use PhpCollective\Dto\Dto\AbstractDto;
 
 /**
  * EmptyOne DTO

--- a/tests/test_app/src/Dto/EnumTestDto.php
+++ b/tests/test_app/src/Dto/EnumTestDto.php
@@ -6,7 +6,7 @@
 
 namespace TestApp\Dto;
 
-use CakeDto\Dto\AbstractImmutableDto;
+use PhpCollective\Dto\Dto\AbstractImmutableDto;
 
 /**
  * EnumTest DTO

--- a/tests/test_app/src/Dto/MutableMetaDto.php
+++ b/tests/test_app/src/Dto/MutableMetaDto.php
@@ -6,7 +6,7 @@
 
 namespace TestApp\Dto;
 
-use CakeDto\Dto\AbstractDto;
+use PhpCollective\Dto\Dto\AbstractDto;
 
 /**
  * MutableMeta DTO

--- a/tests/test_app/src/Dto/OwnerDto.php
+++ b/tests/test_app/src/Dto/OwnerDto.php
@@ -6,7 +6,7 @@
 
 namespace TestApp\Dto;
 
-use CakeDto\Dto\AbstractDto;
+use PhpCollective\Dto\Dto\AbstractDto;
 
 /**
  * Owner DTO

--- a/tests/test_app/src/Dto/PageDto.php
+++ b/tests/test_app/src/Dto/PageDto.php
@@ -6,7 +6,7 @@
 
 namespace TestApp\Dto;
 
-use CakeDto\Dto\AbstractImmutableDto;
+use PhpCollective\Dto\Dto\AbstractImmutableDto;
 
 /**
  * Page DTO

--- a/tests/test_app/src/Dto/TagDto.php
+++ b/tests/test_app/src/Dto/TagDto.php
@@ -6,7 +6,7 @@
 
 namespace TestApp\Dto;
 
-use CakeDto\Dto\AbstractImmutableDto;
+use PhpCollective\Dto\Dto\AbstractImmutableDto;
 
 /**
  * Tag DTO

--- a/tests/test_app/src/Dto/TransactionDto.php
+++ b/tests/test_app/src/Dto/TransactionDto.php
@@ -6,7 +6,7 @@
 
 namespace TestApp\Dto;
 
-use CakeDto\Dto\AbstractImmutableDto;
+use PhpCollective\Dto\Dto\AbstractImmutableDto;
 
 /**
  * Transaction DTO


### PR DESCRIPTION
## Summary

- Remove constructor workarounds now that php-collective/dto 0.1.4 has the fix
- DTOs now use parent library's abstract classes directly
- Regenerated test DTOs

Requires php-collective/dto ^0.1.3 (picks up 0.1.4 with the fix).