### PR TITLE
Bump php-collective/dto minimum to 0.1.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
 		"cakephp/cakephp": "^5.1.1",
 		"cakephp/twig-view": "^2.0.1",
 		"sebastian/diff": "^6.0.0 || ^7.0.0",
-		"php-collective/dto": "^0.1.3"
+		"php-collective/dto": "^0.1.5"
 	},
 	"require-dev": {
 		"ext-dom": "*",


### PR DESCRIPTION
## Summary
- Fixes prefer-lowest CI by ensuring consistent error message format between lowest and latest versions

The error messages in version 0.1.3 had a different format than 0.1.5, causing test expectation failures with prefer-lowest.