### PR TITLE
Fix PHPStan CI errors

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,6 +17,7 @@ parameters:
 		-
 			message: '#does not accept object\|null#'
 			path: tests/test_app/src/Dto/
+		# CakePHP framework covariance issue with EventInterface generics
 		-
-			message: '#does not accept ArrayObject<int, mixed>#'
-			path: tests/test_app/src/Dto/
+			identifier: method.childReturnType
+			path: src/View/DtoView.php

--- a/templates/Dto/element/optimizations.twig
+++ b/templates/Dto/element/optimizations.twig
@@ -79,7 +79,9 @@
 {% endif %}
 				$items[] = $item;
 			}
-			$this->{{ field.name }} = new {{ field.collectionType }}($items);
+			/** @var {{ field.type }} $collection */
+			$collection = new {{ field.collectionType }}($items);
+			$this->{{ field.name }} = $collection;
 			$this->_touchedFields['{{ field.name }}'] = true;
 		}
 {% elseif field.collection and field.collectionType == 'array' and field.singularClass is defined and field.singularClass %}

--- a/tests/test_app/src/Dto/BookDto.php
+++ b/tests/test_app/src/Dto/BookDto.php
@@ -95,7 +95,9 @@ class BookDto extends AbstractImmutableDto {
 				}
 				$items[] = $item;
 			}
-			$this->pages = new \Cake\Collection\Collection($items);
+			/** @var \TestApp\Dto\PageDto[]|\Cake\Collection\Collection $collection */
+			$collection = new \Cake\Collection\Collection($items);
+			$this->pages = $collection;
 			$this->_touchedFields['pages'] = true;
 		}
 	}

--- a/tests/test_app/src/Dto/CarsDto.php
+++ b/tests/test_app/src/Dto/CarsDto.php
@@ -95,7 +95,9 @@ class CarsDto extends AbstractDto {
 				}
 				$items[] = $item;
 			}
-			$this->cars = new \ArrayObject($items);
+			/** @var \TestApp\Dto\CarDto[]|\ArrayObject $collection */
+			$collection = new \ArrayObject($items);
+			$this->cars = $collection;
 			$this->_touchedFields['cars'] = true;
 		}
 	}


### PR DESCRIPTION
## Summary
- Fix collection type annotation in template for proper PHPStan inference
- Add identifier-based ignore for CakePHP framework EventInterface covariance issue
- Regenerate test DTOs with updated template
- Remove obsolete ArrayObject ignore pattern

## Test plan
- [x] PHPStan passes locally
- [x] Tests pass
- [x] CS check passes