### PR TITLE
Add PHPDoc annotation for enum fields in generated DTOs

### DIFF
--- a/templates/Dto/element/optimizations.twig
+++ b/templates/Dto/element/optimizations.twig
@@ -55,6 +55,7 @@
 			if (!is_object($value)) {
 				$value = $this->createEnum('{{ field.name }}', $value);
 			}
+			/** @var {{ field.typeHint }}|null $value */
 			$this->{{ field.name }} = $value;
 			$this->_touchedFields['{{ field.name }}'] = true;
 		}


### PR DESCRIPTION
## Summary
- Adds missing `@var` type annotation for enum fields in `setFromArrayFast()` generated code

The generated code for enum fields was missing the PHPDoc type annotation that `isClass` fields already have. Without this annotation, PHPStan reports errors like:
```
Cannot assign mixed to \App\Enum\MyEnum|null
```

This adds `/** @var {field.typeHint}|null $value */` before the assignment, consistent with how `isClass` fields are handled.

Related: https://github.com/php-collective/dto/pull/50 (fixes createEnum() docblock in base class)