### PR TITLE
Fix template whitespace formatting

### DIFF
--- a/templates/Dto/element/constants.twig
+++ b/templates/Dto/element/constants.twig
@@ -4,12 +4,15 @@
 	 * @deprecated {{ field.deprecated }}
 	 */
 	{% if scalarAndReturnTypes %}public {% endif %}const FIELD_{{ field.name | stripLeadingUnderscore | underscore | upper }} = '{{ field.name }}';
+
 {% elseif typedConstants %}
 	{% if scalarAndReturnTypes %}public {% endif %}const string FIELD_{{ field.name | stripLeadingUnderscore | underscore | upper }} = '{{ field.name }}';
+
 {% else %}
 	/**
 	 * @var string
 	 */
 	{% if scalarAndReturnTypes %}public {% endif %}const FIELD_{{ field.name | stripLeadingUnderscore | underscore | upper }} = '{{ field.name }}';
+
 {% endif %}
 {% endfor -%}

--- a/templates/Dto/element/optimizations.twig
+++ b/templates/Dto/element/optimizations.twig
@@ -1,5 +1,7 @@
 	/**
 	 * Whether this DTO is immutable.
+	 *
+	 * @var bool
 	 */
 	protected const IS_IMMUTABLE = {{ immutable ? 'true' : 'false' }};
 
@@ -106,13 +108,12 @@
 {% endif %}
 {% endfor %}
 	}
-
-{% set fieldsWithDefaults = [] %}
-{% for field in fields %}
-{% if field.defaultValue is not null %}
-{% set fieldsWithDefaults = fieldsWithDefaults | merge([field]) %}
-{% endif %}
-{% endfor %}
+{% set fieldsWithDefaults = [] -%}
+{%- for field in fields -%}
+{%- if field.defaultValue is not null -%}
+{%- set fieldsWithDefaults = fieldsWithDefaults | merge([field]) -%}
+{%- endif -%}
+{%- endfor %}
 
 	/**
 	 * Optimized setDefaults - only processes fields with default values.
@@ -130,12 +131,12 @@
 
 		return $this;
 	}
-{% set requiredFields = [] %}
-{% for field in fields %}
-{% if field.required %}
-{% set requiredFields = requiredFields | merge([field]) %}
-{% endif %}
-{% endfor %}
+{% set requiredFields = [] -%}
+{%- for field in fields -%}
+{%- if field.required -%}
+{%- set requiredFields = requiredFields | merge([field]) -%}
+{%- endif -%}
+{%- endfor %}
 
 	/**
 	 * Optimized validate - only checks required fields.

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/BaseDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/BaseDto.php
@@ -22,18 +22,22 @@ class BaseDto extends AbstractDto {
 	 * @var string
 	 */
 	public const FIELD_REF = 'ref';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_SHA = 'sha';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_USER = 'user';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_REPO = 'repo';
+
 
 	/**
 	 * @var string
@@ -139,6 +143,8 @@ class BaseDto extends AbstractDto {
 
 	/**
 	 * Whether this DTO is immutable.
+	 *
+	 * @var bool
 	 */
 	protected const IS_IMMUTABLE = false;
 
@@ -190,7 +196,6 @@ class BaseDto extends AbstractDto {
 			$this->_touchedFields['repo'] = true;
 		}
 	}
-
 
 	/**
 	 * Optimized setDefaults - only processes fields with default values.

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/HeadDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/HeadDto.php
@@ -22,18 +22,22 @@ class HeadDto extends AbstractDto {
 	 * @var string
 	 */
 	public const FIELD_REF = 'ref';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_SHA = 'sha';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_USER = 'user';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_REPO = 'repo';
+
 
 	/**
 	 * @var string
@@ -139,6 +143,8 @@ class HeadDto extends AbstractDto {
 
 	/**
 	 * Whether this DTO is immutable.
+	 *
+	 * @var bool
 	 */
 	protected const IS_IMMUTABLE = false;
 
@@ -190,7 +196,6 @@ class HeadDto extends AbstractDto {
 			$this->_touchedFields['repo'] = true;
 		}
 	}
-
 
 	/**
 	 * Optimized setDefaults - only processes fields with default values.

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/LabelDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/LabelDto.php
@@ -20,10 +20,12 @@ class LabelDto extends AbstractDto {
 	 * @var string
 	 */
 	public const FIELD_NAME = 'name';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_COLOR = 'color';
+
 
 	/**
 	 * @var string|null
@@ -87,6 +89,8 @@ class LabelDto extends AbstractDto {
 
 	/**
 	 * Whether this DTO is immutable.
+	 *
+	 * @var bool
 	 */
 	protected const IS_IMMUTABLE = false;
 
@@ -120,7 +124,6 @@ class LabelDto extends AbstractDto {
 			$this->_touchedFields['color'] = true;
 		}
 	}
-
 
 	/**
 	 * Optimized setDefaults - only processes fields with default values.

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/PullRequestDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/PullRequestDto.php
@@ -28,42 +28,52 @@ class PullRequestDto extends AbstractDto {
 	 * @var string
 	 */
 	public const FIELD_URL = 'url';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_NUMBER = 'number';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_STATE = 'state';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_TITLE = 'title';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_BODY = 'body';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_USER = 'user';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_CREATED_AT = 'createdAt';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_LABELS = 'labels';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_HEAD = 'head';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_BASE = 'base';
+
 
 	/**
 	 * @var string
@@ -298,6 +308,8 @@ class PullRequestDto extends AbstractDto {
 
 	/**
 	 * Whether this DTO is immutable.
+	 *
+	 * @var bool
 	 */
 	protected const IS_IMMUTABLE = false;
 
@@ -390,7 +402,6 @@ class PullRequestDto extends AbstractDto {
 			$this->_touchedFields['base'] = true;
 		}
 	}
-
 
 	/**
 	 * Optimized setDefaults - only processes fields with default values.

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/RepoDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/RepoDto.php
@@ -22,18 +22,22 @@ class RepoDto extends AbstractDto {
 	 * @var string
 	 */
 	public const FIELD_NAME = 'name';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_HTML_URL = 'htmlUrl';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_PRIVATE = 'private';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_OWNER = 'owner';
+
 
 	/**
 	 * @var string
@@ -139,6 +143,8 @@ class RepoDto extends AbstractDto {
 
 	/**
 	 * Whether this DTO is immutable.
+	 *
+	 * @var bool
 	 */
 	protected const IS_IMMUTABLE = false;
 
@@ -186,7 +192,6 @@ class RepoDto extends AbstractDto {
 			$this->_touchedFields['owner'] = true;
 		}
 	}
-
 
 	/**
 	 * Optimized setDefaults - only processes fields with default values.

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/UserDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/UserDto.php
@@ -21,14 +21,17 @@ class UserDto extends AbstractDto {
 	 * @var string
 	 */
 	public const FIELD_LOGIN = 'login';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_HTML_URL = 'htmlUrl';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_TYPE = 'type';
+
 
 	/**
 	 * @var string
@@ -113,6 +116,8 @@ class UserDto extends AbstractDto {
 
 	/**
 	 * Whether this DTO is immutable.
+	 *
+	 * @var bool
 	 */
 	protected const IS_IMMUTABLE = false;
 
@@ -151,7 +156,6 @@ class UserDto extends AbstractDto {
 			$this->_touchedFields['type'] = true;
 		}
 	}
-
 
 	/**
 	 * Optimized setDefaults - only processes fields with default values.

--- a/tests/test_app/plugins/Sandbox/src/Dto/Jira/IssueDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Jira/IssueDto.php
@@ -24,26 +24,32 @@ class IssueDto extends AbstractDto {
 	 * @var string
 	 */
 	public const FIELD_ID = 'id';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_KEY = 'key';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_STATUS = 'status';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_PRIORITY = 'priority';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_SUMMARY = 'summary';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_VERSION = 'version';
+
 
 	/**
 	 * @var string
@@ -191,6 +197,8 @@ class IssueDto extends AbstractDto {
 
 	/**
 	 * Whether this DTO is immutable.
+	 *
+	 * @var bool
 	 */
 	protected const IS_IMMUTABLE = false;
 
@@ -244,7 +252,6 @@ class IssueDto extends AbstractDto {
 			$this->_touchedFields['version'] = true;
 		}
 	}
-
 
 	/**
 	 * Optimized setDefaults - only processes fields with default values.

--- a/tests/test_app/src/Dto/ArticleDto.php
+++ b/tests/test_app/src/Dto/ArticleDto.php
@@ -24,26 +24,32 @@ class ArticleDto extends AbstractImmutableDto {
 	 * @var string
 	 */
 	public const FIELD_ID = 'id';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_AUTHOR = 'author';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_TITLE = 'title';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_CREATED = 'created';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_TAGS = 'tags';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_META = 'meta';
+
 
 	/**
 	 * @var int
@@ -199,6 +205,8 @@ class ArticleDto extends AbstractImmutableDto {
 
 	/**
 	 * Whether this DTO is immutable.
+	 *
+	 * @var bool
 	 */
 	protected const IS_IMMUTABLE = true;
 
@@ -268,7 +276,6 @@ class ArticleDto extends AbstractImmutableDto {
 			$this->_touchedFields['meta'] = true;
 		}
 	}
-
 
 	/**
 	 * Optimized setDefaults - only processes fields with default values.

--- a/tests/test_app/src/Dto/AuthorDto.php
+++ b/tests/test_app/src/Dto/AuthorDto.php
@@ -21,14 +21,17 @@ class AuthorDto extends AbstractImmutableDto {
 	 * @var string
 	 */
 	public const FIELD_ID = 'id';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_NAME = 'name';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_EMAIL = 'email';
+
 
 	/**
 	 * @var int
@@ -113,6 +116,8 @@ class AuthorDto extends AbstractImmutableDto {
 
 	/**
 	 * Whether this DTO is immutable.
+	 *
+	 * @var bool
 	 */
 	protected const IS_IMMUTABLE = true;
 
@@ -151,7 +156,6 @@ class AuthorDto extends AbstractImmutableDto {
 			$this->_touchedFields['email'] = true;
 		}
 	}
-
 
 	/**
 	 * Optimized setDefaults - only processes fields with default values.

--- a/tests/test_app/src/Dto/BookDto.php
+++ b/tests/test_app/src/Dto/BookDto.php
@@ -20,6 +20,7 @@ class BookDto extends AbstractImmutableDto {
 	 */
 	public const FIELD_PAGES = 'pages';
 
+
 	/**
 	 * @var \Cake\Collection\Collection<int, \TestApp\Dto\PageDto>
 	 */
@@ -64,6 +65,8 @@ class BookDto extends AbstractImmutableDto {
 
 	/**
 	 * Whether this DTO is immutable.
+	 *
+	 * @var bool
 	 */
 	protected const IS_IMMUTABLE = true;
 
@@ -101,7 +104,6 @@ class BookDto extends AbstractImmutableDto {
 			$this->_touchedFields['pages'] = true;
 		}
 	}
-
 
 	/**
 	 * Optimized setDefaults - only processes fields with default values.

--- a/tests/test_app/src/Dto/CarDto.php
+++ b/tests/test_app/src/Dto/CarDto.php
@@ -25,30 +25,37 @@ class CarDto extends AbstractDto {
 	 * @var string
 	 */
 	public const FIELD_COLOR = 'color';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_IS_NEW = 'isNew';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_VALUE = 'value';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_DISTANCE_TRAVELLED = 'distanceTravelled';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_ATTRIBUTES = 'attributes';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_MANUFACTURED = 'manufactured';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_OWNER = 'owner';
+
 
 	/**
 	 * @var \TestApp\ValueObject\Paint|null
@@ -221,6 +228,8 @@ class CarDto extends AbstractDto {
 
 	/**
 	 * Whether this DTO is immutable.
+	 *
+	 * @var bool
 	 */
 	protected const IS_IMMUTABLE = false;
 
@@ -292,7 +301,6 @@ class CarDto extends AbstractDto {
 			$this->_touchedFields['owner'] = true;
 		}
 	}
-
 
 	/**
 	 * Optimized setDefaults - only processes fields with default values.

--- a/tests/test_app/src/Dto/CarsDto.php
+++ b/tests/test_app/src/Dto/CarsDto.php
@@ -20,6 +20,7 @@ class CarsDto extends AbstractDto {
 	 */
 	public const FIELD_CARS = 'cars';
 
+
 	/**
 	 * @var \ArrayObject<string, \TestApp\Dto\CarDto>
 	 */
@@ -64,6 +65,8 @@ class CarsDto extends AbstractDto {
 
 	/**
 	 * Whether this DTO is immutable.
+	 *
+	 * @var bool
 	 */
 	protected const IS_IMMUTABLE = false;
 
@@ -101,7 +104,6 @@ class CarsDto extends AbstractDto {
 			$this->_touchedFields['cars'] = true;
 		}
 	}
-
 
 	/**
 	 * Optimized setDefaults - only processes fields with default values.

--- a/tests/test_app/src/Dto/CustomerAccountDto.php
+++ b/tests/test_app/src/Dto/CustomerAccountDto.php
@@ -21,14 +21,17 @@ class CustomerAccountDto extends AbstractDto {
 	 * @var string
 	 */
 	public const FIELD_CUSTOMER_NAME = 'customerName';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_BIRTH_YEAR = 'birthYear';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_LAST_LOGIN = 'lastLogin';
+
 
 	/**
 	 * @var string
@@ -115,6 +118,8 @@ class CustomerAccountDto extends AbstractDto {
 
 	/**
 	 * Whether this DTO is immutable.
+	 *
+	 * @var bool
 	 */
 	protected const IS_IMMUTABLE = false;
 
@@ -158,7 +163,6 @@ class CustomerAccountDto extends AbstractDto {
 			$this->_touchedFields['lastLogin'] = true;
 		}
 	}
-
 
 	/**
 	 * Optimized setDefaults - only processes fields with default values.

--- a/tests/test_app/src/Dto/EmptyOneDto.php
+++ b/tests/test_app/src/Dto/EmptyOneDto.php
@@ -35,6 +35,8 @@ class EmptyOneDto extends AbstractDto {
 
 	/**
 	 * Whether this DTO is immutable.
+	 *
+	 * @var bool
 	 */
 	protected const IS_IMMUTABLE = false;
 
@@ -58,7 +60,6 @@ class EmptyOneDto extends AbstractDto {
 	 */
 	protected function setFromArrayFast(array $data): void {
 	}
-
 
 	/**
 	 * Optimized setDefaults - only processes fields with default values.

--- a/tests/test_app/src/Dto/EnumTestDto.php
+++ b/tests/test_app/src/Dto/EnumTestDto.php
@@ -21,14 +21,17 @@ class EnumTestDto extends AbstractImmutableDto {
 	 * @var string
 	 */
 	public const FIELD_SOME_UNIT = 'someUnit';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_SOME_STRING_BACKED = 'someStringBacked';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_SOME_INT_BACKED = 'someIntBacked';
+
 
 	/**
 	 * @var \TestApp\Model\Enum\MyUnit|null
@@ -119,6 +122,8 @@ class EnumTestDto extends AbstractImmutableDto {
 
 	/**
 	 * Whether this DTO is immutable.
+	 *
+	 * @var bool
 	 */
 	protected const IS_IMMUTABLE = true;
 
@@ -172,7 +177,6 @@ class EnumTestDto extends AbstractImmutableDto {
 			$this->_touchedFields['someIntBacked'] = true;
 		}
 	}
-
 
 	/**
 	 * Optimized setDefaults - only processes fields with default values.

--- a/tests/test_app/src/Dto/FlyingCarDto.php
+++ b/tests/test_app/src/Dto/FlyingCarDto.php
@@ -20,14 +20,17 @@ class FlyingCarDto extends CarDto {
 	 * @var string
 	 */
 	public const FIELD_MAX_ALTITUDE = 'maxAltitude';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_MAX_SPEED = 'maxSpeed';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_COMPLEX_ATTRIBUTES = 'complexAttributes';
+
 
 	/**
 	 * @var int|null
@@ -112,6 +115,8 @@ class FlyingCarDto extends CarDto {
 
 	/**
 	 * Whether this DTO is immutable.
+	 *
+	 * @var bool
 	 */
 	protected const IS_IMMUTABLE = false;
 
@@ -150,7 +155,6 @@ class FlyingCarDto extends CarDto {
 			$this->_touchedFields['complexAttributes'] = true;
 		}
 	}
-
 
 	/**
 	 * Optimized setDefaults - only processes fields with default values.

--- a/tests/test_app/src/Dto/MutableMetaDto.php
+++ b/tests/test_app/src/Dto/MutableMetaDto.php
@@ -20,10 +20,12 @@ class MutableMetaDto extends AbstractDto {
 	 * @var string
 	 */
 	public const FIELD_TITLE = 'title';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_META = 'meta';
+
 
 	/**
 	 * @var string
@@ -90,6 +92,8 @@ class MutableMetaDto extends AbstractDto {
 
 	/**
 	 * Whether this DTO is immutable.
+	 *
+	 * @var bool
 	 */
 	protected const IS_IMMUTABLE = false;
 
@@ -123,7 +127,6 @@ class MutableMetaDto extends AbstractDto {
 			$this->_touchedFields['meta'] = true;
 		}
 	}
-
 
 	/**
 	 * Optimized setDefaults - only processes fields with default values.

--- a/tests/test_app/src/Dto/OldOneDto.php
+++ b/tests/test_app/src/Dto/OldOneDto.php
@@ -21,6 +21,7 @@ class OldOneDto extends CarDto {
 	 */
 	public const FIELD_NAME = 'name';
 
+
 	/**
 	 * @var string|null
 	 */
@@ -62,6 +63,8 @@ class OldOneDto extends CarDto {
 
 	/**
 	 * Whether this DTO is immutable.
+	 *
+	 * @var bool
 	 */
 	protected const IS_IMMUTABLE = false;
 
@@ -90,7 +93,6 @@ class OldOneDto extends CarDto {
 			$this->_touchedFields['name'] = true;
 		}
 	}
-
 
 	/**
 	 * Optimized setDefaults - only processes fields with default values.

--- a/tests/test_app/src/Dto/OwnerDto.php
+++ b/tests/test_app/src/Dto/OwnerDto.php
@@ -22,18 +22,22 @@ class OwnerDto extends AbstractDto {
 	 * @var string
 	 */
 	public const FIELD_NAME = 'name';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_INSURANCE_PROVIDER = 'insuranceProvider';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_ATTRIBUTES = 'attributes';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_BIRTHDAY = 'birthday';
+
 
 	/**
 	 * @var string|null
@@ -143,6 +147,8 @@ class OwnerDto extends AbstractDto {
 
 	/**
 	 * Whether this DTO is immutable.
+	 *
+	 * @var bool
 	 */
 	protected const IS_IMMUTABLE = false;
 
@@ -195,7 +201,6 @@ class OwnerDto extends AbstractDto {
 			$this->_touchedFields['birthday'] = true;
 		}
 	}
-
 
 	/**
 	 * Optimized setDefaults - only processes fields with default values.

--- a/tests/test_app/src/Dto/PageDto.php
+++ b/tests/test_app/src/Dto/PageDto.php
@@ -20,10 +20,12 @@ class PageDto extends AbstractImmutableDto {
 	 * @var string
 	 */
 	public const FIELD_NUMBER = 'number';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_CONTENT = 'content';
+
 
 	/**
 	 * @var int
@@ -87,6 +89,8 @@ class PageDto extends AbstractImmutableDto {
 
 	/**
 	 * Whether this DTO is immutable.
+	 *
+	 * @var bool
 	 */
 	protected const IS_IMMUTABLE = true;
 
@@ -120,7 +124,6 @@ class PageDto extends AbstractImmutableDto {
 			$this->_touchedFields['content'] = true;
 		}
 	}
-
 
 	/**
 	 * Optimized setDefaults - only processes fields with default values.

--- a/tests/test_app/src/Dto/TagDto.php
+++ b/tests/test_app/src/Dto/TagDto.php
@@ -21,14 +21,17 @@ class TagDto extends AbstractImmutableDto {
 	 * @var string
 	 */
 	public const FIELD_ID = 'id';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_NAME = 'name';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_WEIGHT = 'weight';
+
 
 	/**
 	 * @var int
@@ -113,6 +116,8 @@ class TagDto extends AbstractImmutableDto {
 
 	/**
 	 * Whether this DTO is immutable.
+	 *
+	 * @var bool
 	 */
 	protected const IS_IMMUTABLE = true;
 
@@ -151,7 +156,6 @@ class TagDto extends AbstractImmutableDto {
 			$this->_touchedFields['weight'] = true;
 		}
 	}
-
 
 	/**
 	 * Optimized setDefaults - only processes fields with default values.

--- a/tests/test_app/src/Dto/TransactionDto.php
+++ b/tests/test_app/src/Dto/TransactionDto.php
@@ -22,18 +22,22 @@ class TransactionDto extends AbstractImmutableDto {
 	 * @var string
 	 */
 	public const FIELD_CUSTOMER_ACCOUNT = 'customerAccount';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_VALUE = 'value';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_COMMENT = 'comment';
+
 	/**
 	 * @var string
 	 */
 	public const FIELD_CREATED = 'created';
+
 
 	/**
 	 * @var \TestApp\Dto\CustomerAccountDto
@@ -141,6 +145,8 @@ class TransactionDto extends AbstractImmutableDto {
 
 	/**
 	 * Whether this DTO is immutable.
+	 *
+	 * @var bool
 	 */
 	protected const IS_IMMUTABLE = true;
 
@@ -193,7 +199,6 @@ class TransactionDto extends AbstractImmutableDto {
 			$this->_touchedFields['created'] = true;
 		}
 	}
-
 
 	/**
 	 * Optimized setDefaults - only processes fields with default values.


### PR DESCRIPTION
## Summary

Fixes whitespace formatting issues in generated DTOs:

1. **Blank lines between constants** - Added missing blank lines between constant declarations for better readability

2. **IS_IMMUTABLE annotation** - Added `@var bool` annotation to the `IS_IMMUTABLE` constant

3. **Method spacing** - Fixed Twig whitespace control to maintain proper blank lines between methods in optimizations template

## Changes

- `templates/Dto/element/constants.twig` - Add blank lines between constants
- `templates/Dto/element/optimizations.twig` - Fix whitespace control and add annotation
- Regenerated test DTOs with proper formatting