### PR TITLE
Add Generate DTOs from Database feature

### DIFF
--- a/src/Importer/DatabaseParser.php
+++ b/src/Importer/DatabaseParser.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace CakeDto\Importer;
+
+use Cake\Database\Schema\TableSchemaInterface;
+use Cake\Datasource\ConnectionManager;
+use Cake\Utility\Inflector;
+
+class DatabaseParser {
+
+	/**
+	 * @var array<string, string>
+	 */
+	protected array $typeMap = [
+		'integer' => 'int',
+		'biginteger' => 'int',
+		'smallinteger' => 'int',
+		'tinyinteger' => 'int',
+		'string' => 'string',
+		'text' => 'string',
+		'char' => 'string',
+		'uuid' => 'string',
+		'boolean' => 'bool',
+		'float' => 'float',
+		'decimal' => 'float',
+		'date' => '\Cake\I18n\Date',
+		'datetime' => '\Cake\I18n\DateTime',
+		'timestamp' => '\Cake\I18n\DateTime',
+		'datetimefractional' => '\Cake\I18n\DateTime',
+		'timestampfractional' => '\Cake\I18n\DateTime',
+		'timestamptimezone' => '\Cake\I18n\DateTime',
+		'time' => '\Cake\I18n\Time',
+		'json' => 'array',
+		'binary' => 'string',
+	];
+
+	/**
+	 * @param string $connectionName
+	 *
+	 * @return array<string>
+	 */
+	public function listTables(string $connectionName = 'default'): array {
+		$connection = ConnectionManager::get($connectionName);
+		/** @var \Cake\Database\Connection $connection */
+		$schemaCollection = $connection->getSchemaCollection();
+
+		return $schemaCollection->listTables();
+	}
+
+	/**
+	 * @param array<string> $tables
+	 * @param string $connectionName
+	 *
+	 * @return array<string, array<string, array<string, mixed>>>
+	 */
+	public function parse(array $tables, string $connectionName = 'default'): array {
+		$connection = ConnectionManager::get($connectionName);
+		/** @var \Cake\Database\Connection $connection */
+		$schemaCollection = $connection->getSchemaCollection();
+
+		$result = [];
+		foreach ($tables as $table) {
+			$tableSchema = $schemaCollection->describe($table);
+			$dtoName = $this->tableToDtoName($table);
+			$result[$dtoName] = $this->parseTable($tableSchema);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @param \Cake\Database\Schema\TableSchemaInterface $tableSchema
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	protected function parseTable(TableSchemaInterface $tableSchema): array {
+		$fields = [];
+		$primaryKey = $tableSchema->getPrimaryKey();
+
+		foreach ($tableSchema->columns() as $column) {
+			$columnData = $tableSchema->getColumn($column);
+			if (!$columnData) {
+				continue;
+			}
+
+			$fieldName = Inflector::variable($column);
+			$type = $columnData['type'] ?? 'string';
+			$dtoType = $this->typeMap[$type] ?? 'string';
+
+			$field = [
+				'type' => $dtoType,
+			];
+
+			$isNullable = $columnData['null'] ?? false;
+			$hasDefault = array_key_exists('default', $columnData) && $columnData['default'] !== null;
+			$isAutoIncrement = !empty($columnData['autoIncrement']);
+			$isPrimaryKey = in_array($column, $primaryKey, true);
+
+			if (!$isNullable && !$hasDefault && !$isAutoIncrement && !$isPrimaryKey) {
+				$field['required'] = true;
+			}
+
+			$fields[$fieldName] = $field;
+		}
+
+		return $fields;
+	}
+
+	/**
+	 * @param string $tableName
+	 *
+	 * @return string
+	 */
+	protected function tableToDtoName(string $tableName): string {
+		return Inflector::camelize(Inflector::singularize($tableName));
+	}
+
+}

--- a/templates/Admin/Generate/database.php
+++ b/templates/Admin/Generate/database.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var array<string> $tables
+ * @var mixed $dto
+ * @var mixed $format
+ * @var mixed $namespace
+ * @var mixed $result
+ * @var mixed $schema
+ */
+?>
+<h1>Generate DTO Schema from Database Tables</h1>
+
+<div class="float-end">
+	<?php echo $this->Html->link('Restart', ['action' => 'database']); ?>
+</div>
+
+<?php if (!empty($result)) { ?>
+
+	<h2>Result</h2>
+
+	<div class="mb-3">
+		<?php
+		$formats = ['php' => 'PHP', 'yaml' => 'YAML', 'xml' => 'XML', 'neon' => 'NEON'];
+		foreach ($formats as $formatKey => $formatLabel) {
+			echo $this->Form->create(null, ['style' => 'display: inline-block; margin-right: 5px;']);
+			foreach ($dto as $dtoName => $fields) {
+				foreach ($fields as $fieldName => $details) {
+					if (is_array($details)) {
+						foreach ($details as $detailKey => $detailValue) {
+							echo $this->Form->hidden("dto.{$dtoName}.{$fieldName}.{$detailKey}", ['value' => $detailValue]);
+						}
+					} else {
+						echo $this->Form->hidden("dto.{$dtoName}.{$fieldName}", ['value' => $details]);
+					}
+				}
+			}
+			echo $this->Form->hidden('namespace', ['value' => $namespace ?? '']);
+			echo $this->Form->hidden('format', ['value' => $formatKey]);
+			$btnClass = ($format ?? 'php') === $formatKey ? 'btn btn-primary btn-sm' : 'btn btn-outline-secondary btn-sm';
+			echo $this->Form->button($formatLabel, ['class' => $btnClass]);
+			echo $this->Form->end();
+		}
+		?>
+	</div>
+
+	<div class="position-relative">
+		<button type="button" class="btn btn-sm btn-outline-secondary position-absolute top-0 end-0 m-2" id="copy-btn" title="Copy to clipboard">
+			Copy
+		</button>
+		<pre id="result-code" class="pt-5"><?php echo h($result); ?></pre>
+	</div>
+	<script>
+	document.getElementById('copy-btn').addEventListener('click', function() {
+		var code = document.getElementById('result-code').textContent;
+		var btn = document.getElementById('copy-btn');
+
+		function onSuccess() {
+			btn.innerHTML = 'Copied!';
+			setTimeout(function() {
+				btn.innerHTML = 'Copy';
+			}, 2000);
+		}
+
+		if (navigator.clipboard && navigator.clipboard.writeText) {
+			navigator.clipboard.writeText(code).then(onSuccess);
+		} else {
+			var textarea = document.createElement('textarea');
+			textarea.value = code;
+			textarea.style.position = 'fixed';
+			textarea.style.opacity = '0';
+			document.body.appendChild(textarea);
+			textarea.select();
+			document.execCommand('copy');
+			document.body.removeChild(textarea);
+			onSuccess();
+		}
+	});
+	</script>
+
+<?php } elseif (!empty($schema)) { ?>
+
+	<p>Define which DTOs and fields should be present</p>
+
+	<?php echo $this->Form->create(); ?>
+
+	<?php foreach ($schema as $dtoName => $fields) { ?>
+		<?php echo $this->Form->control('dto.' . h($dtoName) . '._include', ['type' => 'checkbox', 'default' => true, 'label' => '<b>' . h($dtoName) . '</b>', 'escape' => false]); ?>
+		<ul class="">
+		<?php foreach ($fields as $fieldName => $details) { ?>
+			<li class="list-unstyled">
+			<?php
+			$label = $fieldName;
+			$label .= ' [' . $details['type'] .']';
+			if (!empty($details['required'])) {
+				$label.=' (required)';
+			}
+			?>
+			<?php echo $this->Form->control('dto.' . $dtoName . '.' . $fieldName . '._include', ['type' => 'checkbox', 'default' => true, 'label' => $label]); ?>
+			<?php echo $this->Form->hidden('dto.' . $dtoName . '.' . $fieldName . '.type', ['value' => $details['type']]); ?>
+			<?php echo $this->Form->hidden('dto.' . $dtoName . '.' . $fieldName . '.singular', ['value' => $details['singular'] ?? null]); ?>
+			<?php echo $this->Form->hidden('dto.' . $dtoName . '.' . $fieldName . '.associative', ['value' => $details['associative'] ?? null]); ?>
+			<?php echo $this->Form->hidden('dto.' . $dtoName . '.' . $fieldName . '.required', ['value' => $details['required'] ?? null]); ?>
+			</li>
+		<?php } ?>
+		</ul>
+	<?php } ?>
+
+	<?php echo $this->Form->hidden('namespace'); ?>
+
+	<?php echo $this->Form->control('format', [
+		'type' => 'select',
+		'options' => [
+			'php' => 'PHP',
+			'yaml' => 'YAML',
+			'xml' => 'XML',
+			'neon' => 'NEON',
+		],
+		'default' => 'php',
+		'label' => 'Output Format',
+	]); ?>
+
+	<?php echo $this->Form->button('Generate'); ?>
+	<?php echo $this->Form->end(); ?>
+
+<?php } else { ?>
+
+	<p>Select the database tables you want to generate DTOs from:</p>
+
+	<?php echo $this->Form->create(); ?>
+
+	<div class="mb-3">
+		<label>
+			<input type="checkbox" id="select-all"> <b>Select All</b>
+		</label>
+	</div>
+
+	<ul class="list-unstyled">
+	<?php foreach ($tables as $table) { ?>
+		<li>
+			<?php echo $this->Form->control('tables.' . $table, [
+				'type' => 'checkbox',
+				'label' => $table,
+				'class' => 'table-checkbox',
+			]); ?>
+		</li>
+	<?php } ?>
+	</ul>
+
+	<?php echo $this->Form->control('namespace', ['type' => 'text', 'placeholder' => 'Optional namespace prefix', 'label' => 'DTO namespace']); ?>
+
+	<?php echo $this->Form->button('Parse Selected Tables'); ?>
+	<?php echo $this->Form->end(); ?>
+
+	<script>
+	document.getElementById('select-all').addEventListener('change', function() {
+		var checkboxes = document.querySelectorAll('.table-checkbox');
+		for (var i = 0; i < checkboxes.length; i++) {
+			checkboxes[i].checked = this.checked;
+		}
+	});
+	</script>
+
+<?php } ?>

--- a/templates/Admin/Generate/index.php
+++ b/templates/Admin/Generate/index.php
@@ -25,4 +25,7 @@
 	<li>
 		or let it <?php echo $this->Html->link('auto-detect', ['action' => 'schema']); ?>
 	</li>
+	<li>
+		<?php echo $this->Html->link('Database tables', ['action' => 'database']); ?>
+	</li>
 </ul>

--- a/tests/TestCase/Importer/DatabaseParserTest.php
+++ b/tests/TestCase/Importer/DatabaseParserTest.php
@@ -1,0 +1,143 @@
+<?php
+declare(strict_types=1);
+
+namespace CakeDto\Test\TestCase\Importer;
+
+use Cake\Database\Connection;
+use Cake\Database\Driver\Sqlite;
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\TestCase;
+use CakeDto\Importer\DatabaseParser;
+
+class DatabaseParserTest extends TestCase {
+
+	protected DatabaseParser $parser;
+
+	/**
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		ConnectionManager::setConfig('test_dto', [
+			'className' => Connection::class,
+			'driver' => Sqlite::class,
+			'database' => ':memory:',
+		]);
+
+		$connection = ConnectionManager::get('test_dto');
+		/** @var \Cake\Database\Connection $connection */
+		$connection->execute('CREATE TABLE articles (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			title VARCHAR(255) NOT NULL,
+			body TEXT,
+			author_id INTEGER NOT NULL,
+			is_published BOOLEAN DEFAULT 0,
+			rating REAL,
+			published_date DATE,
+			created DATETIME,
+			modified DATETIME
+		)');
+		$connection->execute('CREATE TABLE user_profiles (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			user_id INTEGER NOT NULL,
+			bio TEXT,
+			website VARCHAR(255)
+		)');
+
+		$this->parser = new DatabaseParser();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		ConnectionManager::drop('test_dto');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testListTables(): void {
+		$tables = $this->parser->listTables('test_dto');
+
+		$this->assertContains('articles', $tables);
+		$this->assertContains('user_profiles', $tables);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testParse(): void {
+		$result = $this->parser->parse(['articles'], 'test_dto');
+
+		$this->assertArrayHasKey('Article', $result);
+
+		$fields = $result['Article'];
+		$this->assertArrayHasKey('id', $fields);
+		$this->assertArrayHasKey('title', $fields);
+		$this->assertArrayHasKey('body', $fields);
+		$this->assertArrayHasKey('authorId', $fields);
+		$this->assertArrayHasKey('created', $fields);
+		$this->assertArrayHasKey('modified', $fields);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testParseTypeMapping(): void {
+		$result = $this->parser->parse(['articles'], 'test_dto');
+		$fields = $result['Article'];
+
+		$this->assertSame('int', $fields['id']['type']);
+		$this->assertSame('string', $fields['title']['type']);
+		$this->assertSame('string', $fields['body']['type']);
+		$this->assertSame('int', $fields['authorId']['type']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testParseRequiredFields(): void {
+		$result = $this->parser->parse(['articles'], 'test_dto');
+		$fields = $result['Article'];
+
+		// title is NOT NULL without default and not PK/autoincrement => required
+		$this->assertTrue($fields['title']['required']);
+
+		// author_id is NOT NULL without default => required
+		$this->assertTrue($fields['authorId']['required']);
+
+		// id is autoincrement PK => not required
+		$this->assertArrayNotHasKey('required', $fields['id']);
+
+		// body is nullable => not required
+		$this->assertArrayNotHasKey('required', $fields['body']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testParseMultipleTables(): void {
+		$result = $this->parser->parse(['articles', 'user_profiles'], 'test_dto');
+
+		$this->assertArrayHasKey('Article', $result);
+		$this->assertArrayHasKey('UserProfile', $result);
+
+		$this->assertArrayHasKey('userId', $result['UserProfile']);
+		$this->assertArrayHasKey('bio', $result['UserProfile']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testTableNameConversion(): void {
+		$result = $this->parser->parse(['user_profiles'], 'test_dto');
+
+		$this->assertArrayHasKey('UserProfile', $result);
+		$this->assertArrayNotHasKey('user_profiles', $result);
+	}
+
+}


### PR DESCRIPTION
## Summary

- Add `DatabaseParser` that uses CakePHP's `SchemaCollection` to read table metadata and produce DTO definitions matching the existing parser result format
- Add `database()` action to `GenerateController` with a 3-step workflow: table selection → field review → schema output
- Add "Database tables" link to the Generate index page
- Add unit tests for `DatabaseParser` (type mapping, required detection, table name conversion) and integration tests for the controller action