### PR TITLE
Fix docblock indentation in map.twig template

### DIFF
--- a/templates/Dto/element/map.twig
+++ b/templates/Dto/element/map.twig
@@ -1,6 +1,6 @@
 	/**
-	* @var array<string, array<string, string>>
-	*/
+	 * @var array<string, array<string, string>>
+	 */
 	protected array $_keyMap = [
 		'underscored' => [
 {% for field in fields %}

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/BaseDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/BaseDto.php
@@ -124,8 +124,8 @@ class BaseDto extends AbstractDto {
 	];
 
 	/**
-	* @var array<string, array<string, string>>
-	*/
+	 * @var array<string, array<string, string>>
+	 */
 	protected array $_keyMap = [
 		'underscored' => [
 			'ref' => 'ref',

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/HeadDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/HeadDto.php
@@ -124,8 +124,8 @@ class HeadDto extends AbstractDto {
 	];
 
 	/**
-	* @var array<string, array<string, string>>
-	*/
+	 * @var array<string, array<string, string>>
+	 */
 	protected array $_keyMap = [
 		'underscored' => [
 			'ref' => 'ref',

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/LabelDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/LabelDto.php
@@ -74,8 +74,8 @@ class LabelDto extends AbstractDto {
 	];
 
 	/**
-	* @var array<string, array<string, string>>
-	*/
+	 * @var array<string, array<string, string>>
+	 */
 	protected array $_keyMap = [
 		'underscored' => [
 			'name' => 'name',

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/PullRequestDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/PullRequestDto.php
@@ -277,8 +277,8 @@ class PullRequestDto extends AbstractDto {
 	];
 
 	/**
-	* @var array<string, array<string, string>>
-	*/
+	 * @var array<string, array<string, string>>
+	 */
 	protected array $_keyMap = [
 		'underscored' => [
 			'url' => 'url',

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/RepoDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/RepoDto.php
@@ -124,8 +124,8 @@ class RepoDto extends AbstractDto {
 	];
 
 	/**
-	* @var array<string, array<string, string>>
-	*/
+	 * @var array<string, array<string, string>>
+	 */
 	protected array $_keyMap = [
 		'underscored' => [
 			'name' => 'name',

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/UserDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/UserDto.php
@@ -99,8 +99,8 @@ class UserDto extends AbstractDto {
 	];
 
 	/**
-	* @var array<string, array<string, string>>
-	*/
+	 * @var array<string, array<string, string>>
+	 */
 	protected array $_keyMap = [
 		'underscored' => [
 			'login' => 'login',

--- a/tests/test_app/plugins/Sandbox/src/Dto/Jira/IssueDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Jira/IssueDto.php
@@ -174,8 +174,8 @@ class IssueDto extends AbstractDto {
 	];
 
 	/**
-	* @var array<string, array<string, string>>
-	*/
+	 * @var array<string, array<string, string>>
+	 */
 	protected array $_keyMap = [
 		'underscored' => [
 			'id' => 'id',

--- a/tests/test_app/src/Dto/ArticleDto.php
+++ b/tests/test_app/src/Dto/ArticleDto.php
@@ -182,8 +182,8 @@ class ArticleDto extends AbstractImmutableDto {
 	];
 
 	/**
-	* @var array<string, array<string, string>>
-	*/
+	 * @var array<string, array<string, string>>
+	 */
 	protected array $_keyMap = [
 		'underscored' => [
 			'id' => 'id',

--- a/tests/test_app/src/Dto/AuthorDto.php
+++ b/tests/test_app/src/Dto/AuthorDto.php
@@ -99,8 +99,8 @@ class AuthorDto extends AbstractImmutableDto {
 	];
 
 	/**
-	* @var array<string, array<string, string>>
-	*/
+	 * @var array<string, array<string, string>>
+	 */
 	protected array $_keyMap = [
 		'underscored' => [
 			'id' => 'id',

--- a/tests/test_app/src/Dto/BookDto.php
+++ b/tests/test_app/src/Dto/BookDto.php
@@ -52,8 +52,8 @@ class BookDto extends AbstractImmutableDto {
 	];
 
 	/**
-	* @var array<string, array<string, string>>
-	*/
+	 * @var array<string, array<string, string>>
+	 */
 	protected array $_keyMap = [
 		'underscored' => [
 			'pages' => 'pages',

--- a/tests/test_app/src/Dto/CarDto.php
+++ b/tests/test_app/src/Dto/CarDto.php
@@ -203,8 +203,8 @@ class CarDto extends AbstractDto {
 	];
 
 	/**
-	* @var array<string, array<string, string>>
-	*/
+	 * @var array<string, array<string, string>>
+	 */
 	protected array $_keyMap = [
 		'underscored' => [
 			'color' => 'color',

--- a/tests/test_app/src/Dto/CarsDto.php
+++ b/tests/test_app/src/Dto/CarsDto.php
@@ -52,8 +52,8 @@ class CarsDto extends AbstractDto {
 	];
 
 	/**
-	* @var array<string, array<string, string>>
-	*/
+	 * @var array<string, array<string, string>>
+	 */
 	protected array $_keyMap = [
 		'underscored' => [
 			'cars' => 'cars',

--- a/tests/test_app/src/Dto/CustomerAccountDto.php
+++ b/tests/test_app/src/Dto/CustomerAccountDto.php
@@ -101,8 +101,8 @@ class CustomerAccountDto extends AbstractDto {
 	];
 
 	/**
-	* @var array<string, array<string, string>>
-	*/
+	 * @var array<string, array<string, string>>
+	 */
 	protected array $_keyMap = [
 		'underscored' => [
 			'customer_name' => 'customerName',

--- a/tests/test_app/src/Dto/EmptyOneDto.php
+++ b/tests/test_app/src/Dto/EmptyOneDto.php
@@ -24,8 +24,8 @@ class EmptyOneDto extends AbstractDto {
 	];
 
 	/**
-	* @var array<string, array<string, string>>
-	*/
+	 * @var array<string, array<string, string>>
+	 */
 	protected array $_keyMap = [
 		'underscored' => [
 		],

--- a/tests/test_app/src/Dto/EnumTestDto.php
+++ b/tests/test_app/src/Dto/EnumTestDto.php
@@ -105,8 +105,8 @@ class EnumTestDto extends AbstractImmutableDto {
 	];
 
 	/**
-	* @var array<string, array<string, string>>
-	*/
+	 * @var array<string, array<string, string>>
+	 */
 	protected array $_keyMap = [
 		'underscored' => [
 			'some_unit' => 'someUnit',

--- a/tests/test_app/src/Dto/FlyingCarDto.php
+++ b/tests/test_app/src/Dto/FlyingCarDto.php
@@ -98,8 +98,8 @@ class FlyingCarDto extends CarDto {
 	];
 
 	/**
-	* @var array<string, array<string, string>>
-	*/
+	 * @var array<string, array<string, string>>
+	 */
 	protected array $_keyMap = [
 		'underscored' => [
 			'max_altitude' => 'maxAltitude',

--- a/tests/test_app/src/Dto/MutableMetaDto.php
+++ b/tests/test_app/src/Dto/MutableMetaDto.php
@@ -77,8 +77,8 @@ class MutableMetaDto extends AbstractDto {
 	];
 
 	/**
-	* @var array<string, array<string, string>>
-	*/
+	 * @var array<string, array<string, string>>
+	 */
 	protected array $_keyMap = [
 		'underscored' => [
 			'title' => 'title',

--- a/tests/test_app/src/Dto/OldOneDto.php
+++ b/tests/test_app/src/Dto/OldOneDto.php
@@ -50,8 +50,8 @@ class OldOneDto extends CarDto {
 	];
 
 	/**
-	* @var array<string, array<string, string>>
-	*/
+	 * @var array<string, array<string, string>>
+	 */
 	protected array $_keyMap = [
 		'underscored' => [
 			'name' => 'name',

--- a/tests/test_app/src/Dto/OwnerDto.php
+++ b/tests/test_app/src/Dto/OwnerDto.php
@@ -128,8 +128,8 @@ class OwnerDto extends AbstractDto {
 	];
 
 	/**
-	* @var array<string, array<string, string>>
-	*/
+	 * @var array<string, array<string, string>>
+	 */
 	protected array $_keyMap = [
 		'underscored' => [
 			'name' => 'name',

--- a/tests/test_app/src/Dto/PageDto.php
+++ b/tests/test_app/src/Dto/PageDto.php
@@ -74,8 +74,8 @@ class PageDto extends AbstractImmutableDto {
 	];
 
 	/**
-	* @var array<string, array<string, string>>
-	*/
+	 * @var array<string, array<string, string>>
+	 */
 	protected array $_keyMap = [
 		'underscored' => [
 			'number' => 'number',

--- a/tests/test_app/src/Dto/TagDto.php
+++ b/tests/test_app/src/Dto/TagDto.php
@@ -99,8 +99,8 @@ class TagDto extends AbstractImmutableDto {
 	];
 
 	/**
-	* @var array<string, array<string, string>>
-	*/
+	 * @var array<string, array<string, string>>
+	 */
 	protected array $_keyMap = [
 		'underscored' => [
 			'id' => 'id',

--- a/tests/test_app/src/Dto/TransactionDto.php
+++ b/tests/test_app/src/Dto/TransactionDto.php
@@ -126,8 +126,8 @@ class TransactionDto extends AbstractImmutableDto {
 	];
 
 	/**
-	* @var array<string, array<string, string>>
-	*/
+	 * @var array<string, array<string, string>>
+	 */
 	protected array $_keyMap = [
 		'underscored' => [
 			'customer_account' => 'customerAccount',


### PR DESCRIPTION
## Summary

- Fix `$_keyMap` docblock in `map.twig` using `TAB*` instead of `TAB *` (missing space after tab)
- Update all generated test app DTOs to match