### PR TITLE
Add native type declarations to generated DTOs

### DIFF
--- a/templates/Dto/element/method_add.twig
+++ b/templates/Dto/element/method_add.twig
@@ -12,7 +12,7 @@
 	 * @param {% if singularType %}{{ singularType }}{% else %}mixed{% endif %}{% if singularNullable %}|null{% endif %} ${{ singular }}
 	 * @return $this
 	 */
-	public function add{{ cleanSingular[:1]|upper ~ cleanSingular[1:] }}({% if associative %}$key, {% endif %}{% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }}) {
+	public function add{{ cleanSingular[:1]|upper ~ cleanSingular[1:] }}({% if associative %}{{ keyType }} $key, {% endif %}{% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }}): static {
 		if ($this->{{ name }} === null) {
 			$this->{{ name }} = {% if collectionType == 'array' %}[]{% else %}{{ adapter.createEmptyCode(typeHint) }}{% endif %};
 		}

--- a/templates/Dto/element/method_get.twig
+++ b/templates/Dto/element/method_get.twig
@@ -33,7 +33,7 @@
 {% endif %}
 	 */
 {% set cleanSingular = singular | stripLeadingUnderscore %}
-	public function get{{ cleanSingular[:1]|upper ~ cleanSingular[1:] }}($key){% if singularReturnTypeHint %}: {% if singularNullable %}?{% endif %}{{ singularReturnTypeHint }}{% endif %} {
+	public function get{{ cleanSingular[:1]|upper ~ cleanSingular[1:] }}({{ keyType }} $key){% if singularReturnTypeHint %}: {% if singularNullable %}?{% endif %}{{ singularReturnTypeHint }}{% endif %} {
 {% if singularNullable %}
 		if (!isset($this->{{ name }}[$key])) {
 			return null;

--- a/templates/Dto/element/method_has.twig
+++ b/templates/Dto/element/method_has.twig
@@ -33,7 +33,7 @@
 	 * @return bool
 	 */
 {% set cleanSingular = singular | stripLeadingUnderscore %}
-	public function has{{ cleanSingular[:1]|upper ~ cleanSingular[1:] }}($key){% if scalarAndReturnTypes %}: bool{% endif %} {
+	public function has{{ cleanSingular[:1]|upper ~ cleanSingular[1:] }}({{ keyType }} $key){% if scalarAndReturnTypes %}: bool{% endif %} {
 		return isset($this->{{ name }}[$key]);
 	}
 {% endif -%}

--- a/templates/Dto/element/method_set.twig
+++ b/templates/Dto/element/method_set.twig
@@ -8,7 +8,7 @@
 	 *
 	 * @return $this
 	 */
-	public function set{{ cleanName[:1]|upper ~ cleanName[1:] }}({% if typeHint %}{{ nullableTypeHint ?? typeHint }} {% endif %}${{ name }}{% if typeHint and nullable and not scalarAndReturnTypes %} = null{% endif %}) {
+	public function set{{ cleanName[:1]|upper ~ cleanName[1:] }}({% if typeHint %}{{ nullableTypeHint ?? typeHint }} {% endif %}${{ name }}{% if typeHint and nullable and not scalarAndReturnTypes %} = null{% endif %}): static {
 		$this->{{ name }} = ${{ name }};
 		$this->_touchedFields[static::FIELD_{{ name | stripLeadingUnderscore | underscore | upper }}] = true;
 

--- a/templates/Dto/element/method_set_or_fail.twig
+++ b/templates/Dto/element/method_set_or_fail.twig
@@ -12,7 +12,7 @@
 	 *
 	 * @return $this
 	 */
-	public function set{{ cleanName[:1]|upper ~ cleanName[1:] }}OrFail({% if typeHint %}{{ typeHint }} {% endif %}${{ name }}) {
+	public function set{{ cleanName[:1]|upper ~ cleanName[1:] }}OrFail({% if typeHint %}{{ typeHint }} {% endif %}${{ name }}): static {
 {% if not typeHint %}
 		if (${{ name }} === null) {
 			throw new \RuntimeException('Value not present (expected to be not null)');

--- a/templates/Dto/element/method_with.twig
+++ b/templates/Dto/element/method_with.twig
@@ -8,7 +8,7 @@
 	 *
 	 * @return static
 	 */
-	public function with{{ cleanName[:1]|upper ~ cleanName[1:] }}({% if typeHint %}{{ nullableTypeHint ?? typeHint }} {% endif %}${{ name }}{% if typeHint and nullable %} = null{% endif %}) {
+	public function with{{ cleanName[:1]|upper ~ cleanName[1:] }}({% if typeHint %}{{ nullableTypeHint ?? typeHint }} {% endif %}${{ name }}{% if typeHint and nullable %} = null{% endif %}): static {
 		$new = clone $this;
 		$new->{{ name }} = ${{ name }};
 		$new->_touchedFields[static::FIELD_{{ name | stripLeadingUnderscore | underscore | upper }}] = true;

--- a/templates/Dto/element/method_with_added.twig
+++ b/templates/Dto/element/method_with_added.twig
@@ -12,7 +12,7 @@
 	 * @param {{ singularType }}{% if singularNullable %}|null{% endif %} ${{ singular }}
 	 * @return static
 	 */
-	public function withAdded{{ cleanSingular[:1]|upper ~ cleanSingular[1:] }}({% if associative %}$key, {% endif %}{% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }}) {
+	public function withAdded{{ cleanSingular[:1]|upper ~ cleanSingular[1:] }}({% if associative %}{{ keyType }} $key, {% endif %}{% if singularTypeHint %}{% if singularNullable %}?{% endif %}{{ singularTypeHint }} {% endif %}${{ singular }}): static {
 		$new = clone $this;
 
 		if ($new->{{ name }} === null) {

--- a/templates/Dto/element/method_with_or_fail.twig
+++ b/templates/Dto/element/method_with_or_fail.twig
@@ -12,7 +12,7 @@
 	 *
 	 * @return static
 	 */
-	public function with{{ cleanName[:1]|upper ~ cleanName[1:] }}OrFail({% if typeHint %}{{ typeHint }} {% endif %}${{ name }}) {
+	public function with{{ cleanName[:1]|upper ~ cleanName[1:] }}OrFail({% if typeHint %}{{ typeHint }} {% endif %}${{ name }}): static {
 {% if not typeHint %}
 		if (${{ name }} === null) {
 			throw new \RuntimeException('Value not present (expected to be not null)');

--- a/templates/Dto/element/optimizations.twig
+++ b/templates/Dto/element/optimizations.twig
@@ -178,7 +178,7 @@
 	 *
 	 * @return $this
 	 */
-	protected function setDefaults() {
+	protected function setDefaults(): static {
 {% if fieldsWithDefaults | length > 0 %}
 {% for field in fieldsWithDefaults %}
 		if ($this->{{ field.name }} === null) {

--- a/templates/Dto/element/property.twig
+++ b/templates/Dto/element/property.twig
@@ -1,4 +1,4 @@
 	/**
 	 * @var {{ docBlockType ?? type }}{% if nullable %}|null{% endif ~%}
 	 */
-	protected ${{ name }};
+	protected {% if nullable and typeHint %}?{{ typeHint }} {% endif %}${{ name }}{% if nullable and typeHint %} = null{% endif %};

--- a/tests/files/CarDto/set.txt
+++ b/tests/files/CarDto/set.txt
@@ -3,7 +3,7 @@
 	 *
 	 * @return $this
 	 */
-	public function setDistanceTravelled($distanceTravelled) {
+	public function setDistanceTravelled($distanceTravelled): static {
 		$this->distanceTravelled = $distanceTravelled;
 		$this->_touchedFields[static::FIELD_DISTANCE_TRAVELLED] = true;
 

--- a/tests/files/Namespaced/MyTreeDto/setValue.txt
+++ b/tests/files/Namespaced/MyTreeDto/setValue.txt
@@ -3,7 +3,7 @@
 	 *
 	 * @return $this
 	 */
-	public function setValue($value) {
+	public function setValue($value): static {
 		$this->value = $value;
 		$this->_touchedFields[static::FIELD_VALUE] = true;
 

--- a/tests/files/ScalarAndReturnTypes/CarDto/setDistanceTravelled.txt
+++ b/tests/files/ScalarAndReturnTypes/CarDto/setDistanceTravelled.txt
@@ -3,7 +3,7 @@
 	 *
 	 * @return $this
 	 */
-	public function setDistanceTravelled(?int $distanceTravelled) {
+	public function setDistanceTravelled(?int $distanceTravelled): static {
 		$this->distanceTravelled = $distanceTravelled;
 		$this->_touchedFields[static::FIELD_DISTANCE_TRAVELLED] = true;
 

--- a/tests/files/ScalarAndReturnTypes/CarsDto/addCar.txt
+++ b/tests/files/ScalarAndReturnTypes/CarsDto/addCar.txt
@@ -3,7 +3,7 @@
 	 * @param \App\Dto\CarDto $car
 	 * @return $this
 	 */
-	public function addCar($key, \App\Dto\CarDto $car) {
+	public function addCar(string $key, \App\Dto\CarDto $car): static {
 		if ($this->cars === null) {
 			$this->cars = new \ArrayObject([]);
 		}

--- a/tests/files/ScalarAndReturnTypes/DefaultValueDto/setDefaultedOptionalField.txt
+++ b/tests/files/ScalarAndReturnTypes/DefaultValueDto/setDefaultedOptionalField.txt
@@ -3,7 +3,7 @@
 	 *
 	 * @return $this
 	 */
-	public function setDefaultedOptionalField(?int $defaultedOptionalField) {
+	public function setDefaultedOptionalField(?int $defaultedOptionalField): static {
 		$this->defaultedOptionalField = $defaultedOptionalField;
 		$this->_touchedFields[static::FIELD_DEFAULTED_OPTIONAL_FIELD] = true;
 

--- a/tests/files/ScalarAndReturnTypes/FlyingCarDto/setMaxAltitude.txt
+++ b/tests/files/ScalarAndReturnTypes/FlyingCarDto/setMaxAltitude.txt
@@ -3,7 +3,7 @@
 	 *
 	 * @return $this
 	 */
-	public function setMaxAltitude(?int $maxAltitude) {
+	public function setMaxAltitude(?int $maxAltitude): static {
 		$this->maxAltitude = $maxAltitude;
 		$this->_touchedFields[static::FIELD_MAX_ALTITUDE] = true;
 

--- a/tests/files/TreeDto/methods.txt
+++ b/tests/files/TreeDto/methods.txt
@@ -5,7 +5,7 @@
 	 *
 	 * @return $this
 	 */
-	public function setSize($size) {
+	public function setSize($size): static {
 		$this->size = $size;
 		$this->_touchedFields[static::FIELD_SIZE] = true;
 
@@ -21,7 +21,7 @@
 	 *
 	 * @return $this
 	 */
-	public function setSizeOrFail($size) {
+	public function setSizeOrFail($size): static {
 		if ($size === null) {
 			throw new \RuntimeException('Value not present (expected to be not null)');
 		}

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/BaseDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/BaseDto.php
@@ -221,7 +221,7 @@ class BaseDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	protected function setDefaults() {
+	protected function setDefaults(): static {
 
 		return $this;
 	}
@@ -260,7 +260,7 @@ class BaseDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setRef(string $ref) {
+	public function setRef(string $ref): static {
 		$this->ref = $ref;
 		$this->_touchedFields[static::FIELD_REF] = true;
 
@@ -286,7 +286,7 @@ class BaseDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setSha(string $sha) {
+	public function setSha(string $sha): static {
 		$this->sha = $sha;
 		$this->_touchedFields[static::FIELD_SHA] = true;
 
@@ -312,7 +312,7 @@ class BaseDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setUser(\Sandbox\Dto\Github\UserDto $user) {
+	public function setUser(\Sandbox\Dto\Github\UserDto $user): static {
 		$this->user = $user;
 		$this->_touchedFields[static::FIELD_USER] = true;
 
@@ -338,7 +338,7 @@ class BaseDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setRepo(\Sandbox\Dto\Github\RepoDto $repo) {
+	public function setRepo(\Sandbox\Dto\Github\RepoDto $repo): static {
 		$this->repo = $repo;
 		$this->_touchedFields[static::FIELD_REPO] = true;
 

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/HeadDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/HeadDto.php
@@ -221,7 +221,7 @@ class HeadDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	protected function setDefaults() {
+	protected function setDefaults(): static {
 
 		return $this;
 	}
@@ -260,7 +260,7 @@ class HeadDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setRef(string $ref) {
+	public function setRef(string $ref): static {
 		$this->ref = $ref;
 		$this->_touchedFields[static::FIELD_REF] = true;
 
@@ -286,7 +286,7 @@ class HeadDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setSha(string $sha) {
+	public function setSha(string $sha): static {
 		$this->sha = $sha;
 		$this->_touchedFields[static::FIELD_SHA] = true;
 
@@ -312,7 +312,7 @@ class HeadDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setUser(\Sandbox\Dto\Github\UserDto $user) {
+	public function setUser(\Sandbox\Dto\Github\UserDto $user): static {
 		$this->user = $user;
 		$this->_touchedFields[static::FIELD_USER] = true;
 
@@ -338,7 +338,7 @@ class HeadDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setRepo(\Sandbox\Dto\Github\RepoDto $repo) {
+	public function setRepo(\Sandbox\Dto\Github\RepoDto $repo): static {
 		$this->repo = $repo;
 		$this->_touchedFields[static::FIELD_REPO] = true;
 

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/LabelDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/LabelDto.php
@@ -30,12 +30,12 @@ class LabelDto extends AbstractDto {
 	/**
 	 * @var string|null
 	 */
-	protected $name;
+	protected ?string $name = null;
 
 	/**
 	 * @var string|null
 	 */
-	protected $color;
+	protected ?string $color = null;
 
 	/**
 	 * Some data is only for debugging for now.
@@ -147,7 +147,7 @@ class LabelDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	protected function setDefaults() {
+	protected function setDefaults(): static {
 
 		return $this;
 	}
@@ -168,7 +168,7 @@ class LabelDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setName(?string $name) {
+	public function setName(?string $name): static {
 		$this->name = $name;
 		$this->_touchedFields[static::FIELD_NAME] = true;
 
@@ -180,7 +180,7 @@ class LabelDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setNameOrFail(string $name) {
+	public function setNameOrFail(string $name): static {
 		$this->name = $name;
 		$this->_touchedFields[static::FIELD_NAME] = true;
 
@@ -219,7 +219,7 @@ class LabelDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setColor(?string $color) {
+	public function setColor(?string $color): static {
 		$this->color = $color;
 		$this->_touchedFields[static::FIELD_COLOR] = true;
 
@@ -231,7 +231,7 @@ class LabelDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setColorOrFail(string $color) {
+	public function setColorOrFail(string $color): static {
 		$this->color = $color;
 		$this->_touchedFields[static::FIELD_COLOR] = true;
 

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/PullRequestDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/PullRequestDto.php
@@ -118,12 +118,12 @@ class PullRequestDto extends AbstractDto {
 	/**
 	 * @var \Sandbox\Dto\Github\HeadDto|null
 	 */
-	protected $head;
+	protected ?\Sandbox\Dto\Github\HeadDto $head = null;
 
 	/**
 	 * @var \Sandbox\Dto\Github\BaseDto|null
 	 */
-	protected $base;
+	protected ?\Sandbox\Dto\Github\BaseDto $base = null;
 
 	/**
 	 * Some data is only for debugging for now.
@@ -442,7 +442,7 @@ class PullRequestDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	protected function setDefaults() {
+	protected function setDefaults(): static {
 
 		return $this;
 	}
@@ -490,7 +490,7 @@ class PullRequestDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setUrl(string $url) {
+	public function setUrl(string $url): static {
 		$this->url = $url;
 		$this->_touchedFields[static::FIELD_URL] = true;
 
@@ -516,7 +516,7 @@ class PullRequestDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setNumber(int $number) {
+	public function setNumber(int $number): static {
 		$this->number = $number;
 		$this->_touchedFields[static::FIELD_NUMBER] = true;
 
@@ -542,7 +542,7 @@ class PullRequestDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setState(string $state) {
+	public function setState(string $state): static {
 		$this->state = $state;
 		$this->_touchedFields[static::FIELD_STATE] = true;
 
@@ -568,7 +568,7 @@ class PullRequestDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setTitle(string $title) {
+	public function setTitle(string $title): static {
 		$this->title = $title;
 		$this->_touchedFields[static::FIELD_TITLE] = true;
 
@@ -594,7 +594,7 @@ class PullRequestDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setBody(string $body) {
+	public function setBody(string $body): static {
 		$this->body = $body;
 		$this->_touchedFields[static::FIELD_BODY] = true;
 
@@ -620,7 +620,7 @@ class PullRequestDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setUser(\Sandbox\Dto\Github\UserDto $user) {
+	public function setUser(\Sandbox\Dto\Github\UserDto $user): static {
 		$this->user = $user;
 		$this->_touchedFields[static::FIELD_USER] = true;
 
@@ -646,7 +646,7 @@ class PullRequestDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setCreatedAt(string $createdAt) {
+	public function setCreatedAt(string $createdAt): static {
 		$this->createdAt = $createdAt;
 		$this->_touchedFields[static::FIELD_CREATED_AT] = true;
 
@@ -672,7 +672,7 @@ class PullRequestDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setLabels(array $labels) {
+	public function setLabels(array $labels): static {
 		$this->labels = $labels;
 		$this->_touchedFields[static::FIELD_LABELS] = true;
 
@@ -697,7 +697,7 @@ class PullRequestDto extends AbstractDto {
 	 *
 	 * @throws \RuntimeException If value with this key is not set.
 	 */
-	public function getLabel($key): \Sandbox\Dto\Github\LabelDto {
+	public function getLabel(string $key): \Sandbox\Dto\Github\LabelDto {
 		if (!isset($this->labels[$key])) {
 			throw new \RuntimeException(sprintf('Value not set for field `labels` and key `%s` (expected to be not null)', $key));
 		}
@@ -720,7 +720,7 @@ class PullRequestDto extends AbstractDto {
 	 * @param string $key
 	 * @return bool
 	 */
-	public function hasLabel($key): bool {
+	public function hasLabel(string $key): bool {
 		return isset($this->labels[$key]);
 	}
 
@@ -729,7 +729,7 @@ class PullRequestDto extends AbstractDto {
 	 * @param \Sandbox\Dto\Github\LabelDto $label
 	 * @return $this
 	 */
-	public function addLabel($key, \Sandbox\Dto\Github\LabelDto $label) {
+	public function addLabel(string $key, \Sandbox\Dto\Github\LabelDto $label): static {
 		if ($this->labels === null) {
 			$this->labels = [];
 		}
@@ -745,7 +745,7 @@ class PullRequestDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setHead(?\Sandbox\Dto\Github\HeadDto $head) {
+	public function setHead(?\Sandbox\Dto\Github\HeadDto $head): static {
 		$this->head = $head;
 		$this->_touchedFields[static::FIELD_HEAD] = true;
 
@@ -757,7 +757,7 @@ class PullRequestDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setHeadOrFail(\Sandbox\Dto\Github\HeadDto $head) {
+	public function setHeadOrFail(\Sandbox\Dto\Github\HeadDto $head): static {
 		$this->head = $head;
 		$this->_touchedFields[static::FIELD_HEAD] = true;
 
@@ -796,7 +796,7 @@ class PullRequestDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setBase(?\Sandbox\Dto\Github\BaseDto $base) {
+	public function setBase(?\Sandbox\Dto\Github\BaseDto $base): static {
 		$this->base = $base;
 		$this->_touchedFields[static::FIELD_BASE] = true;
 
@@ -808,7 +808,7 @@ class PullRequestDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setBaseOrFail(\Sandbox\Dto\Github\BaseDto $base) {
+	public function setBaseOrFail(\Sandbox\Dto\Github\BaseDto $base): static {
 		$this->base = $base;
 		$this->_touchedFields[static::FIELD_BASE] = true;
 

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/RepoDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/RepoDto.php
@@ -217,7 +217,7 @@ class RepoDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	protected function setDefaults() {
+	protected function setDefaults(): static {
 
 		return $this;
 	}
@@ -256,7 +256,7 @@ class RepoDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setName(string $name) {
+	public function setName(string $name): static {
 		$this->name = $name;
 		$this->_touchedFields[static::FIELD_NAME] = true;
 
@@ -282,7 +282,7 @@ class RepoDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setHtmlUrl(string $htmlUrl) {
+	public function setHtmlUrl(string $htmlUrl): static {
 		$this->htmlUrl = $htmlUrl;
 		$this->_touchedFields[static::FIELD_HTML_URL] = true;
 
@@ -308,7 +308,7 @@ class RepoDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setPrivate(bool $private) {
+	public function setPrivate(bool $private): static {
 		$this->private = $private;
 		$this->_touchedFields[static::FIELD_PRIVATE] = true;
 
@@ -334,7 +334,7 @@ class RepoDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setOwner(\Sandbox\Dto\Github\UserDto $owner) {
+	public function setOwner(\Sandbox\Dto\Github\UserDto $owner): static {
 		$this->owner = $owner;
 		$this->_touchedFields[static::FIELD_OWNER] = true;
 

--- a/tests/test_app/plugins/Sandbox/src/Dto/Github/UserDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Github/UserDto.php
@@ -180,7 +180,7 @@ class UserDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	protected function setDefaults() {
+	protected function setDefaults(): static {
 
 		return $this;
 	}
@@ -216,7 +216,7 @@ class UserDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setLogin(string $login) {
+	public function setLogin(string $login): static {
 		$this->login = $login;
 		$this->_touchedFields[static::FIELD_LOGIN] = true;
 
@@ -242,7 +242,7 @@ class UserDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setHtmlUrl(string $htmlUrl) {
+	public function setHtmlUrl(string $htmlUrl): static {
 		$this->htmlUrl = $htmlUrl;
 		$this->_touchedFields[static::FIELD_HTML_URL] = true;
 
@@ -268,7 +268,7 @@ class UserDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setType(string $type) {
+	public function setType(string $type): static {
 		$this->type = $type;
 		$this->_touchedFields[static::FIELD_TYPE] = true;
 

--- a/tests/test_app/plugins/Sandbox/src/Dto/Jira/IssueDto.php
+++ b/tests/test_app/plugins/Sandbox/src/Dto/Jira/IssueDto.php
@@ -79,7 +79,7 @@ class IssueDto extends AbstractDto {
 	/**
 	 * @var string|null
 	 */
-	protected $version;
+	protected ?string $version = null;
 
 	/**
 	 * Some data is only for debugging for now.
@@ -279,7 +279,7 @@ class IssueDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	protected function setDefaults() {
+	protected function setDefaults(): static {
 
 		return $this;
 	}
@@ -321,7 +321,7 @@ class IssueDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setId(string $id) {
+	public function setId(string $id): static {
 		$this->id = $id;
 		$this->_touchedFields[static::FIELD_ID] = true;
 
@@ -347,7 +347,7 @@ class IssueDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setKey(string $key) {
+	public function setKey(string $key): static {
 		$this->key = $key;
 		$this->_touchedFields[static::FIELD_KEY] = true;
 
@@ -373,7 +373,7 @@ class IssueDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setStatus(string $status) {
+	public function setStatus(string $status): static {
 		$this->status = $status;
 		$this->_touchedFields[static::FIELD_STATUS] = true;
 
@@ -399,7 +399,7 @@ class IssueDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setPriority(string $priority) {
+	public function setPriority(string $priority): static {
 		$this->priority = $priority;
 		$this->_touchedFields[static::FIELD_PRIORITY] = true;
 
@@ -425,7 +425,7 @@ class IssueDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setSummary(string $summary) {
+	public function setSummary(string $summary): static {
 		$this->summary = $summary;
 		$this->_touchedFields[static::FIELD_SUMMARY] = true;
 
@@ -451,7 +451,7 @@ class IssueDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setVersion(?string $version) {
+	public function setVersion(?string $version): static {
 		$this->version = $version;
 		$this->_touchedFields[static::FIELD_VERSION] = true;
 
@@ -463,7 +463,7 @@ class IssueDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setVersionOrFail(string $version) {
+	public function setVersionOrFail(string $version): static {
 		$this->version = $version;
 		$this->_touchedFields[static::FIELD_VERSION] = true;
 

--- a/tests/test_app/src/Dto/ArticleDto.php
+++ b/tests/test_app/src/Dto/ArticleDto.php
@@ -312,7 +312,7 @@ class ArticleDto extends AbstractImmutableDto {
 	 *
 	 * @return $this
 	 */
-	protected function setDefaults() {
+	protected function setDefaults(): static {
 
 		return $this;
 	}
@@ -351,7 +351,7 @@ class ArticleDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withId(int $id) {
+	public function withId(int $id): static {
 		$new = clone $this;
 		$new->id = $id;
 		$new->_touchedFields[static::FIELD_ID] = true;
@@ -378,7 +378,7 @@ class ArticleDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withAuthor(\TestApp\Dto\AuthorDto $author) {
+	public function withAuthor(\TestApp\Dto\AuthorDto $author): static {
 		$new = clone $this;
 		$new->author = $author;
 		$new->_touchedFields[static::FIELD_AUTHOR] = true;
@@ -405,7 +405,7 @@ class ArticleDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withTitle(string $title) {
+	public function withTitle(string $title): static {
 		$new = clone $this;
 		$new->title = $title;
 		$new->_touchedFields[static::FIELD_TITLE] = true;
@@ -432,7 +432,7 @@ class ArticleDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withCreated(\Cake\I18n\Date $created) {
+	public function withCreated(\Cake\I18n\Date $created): static {
 		$new = clone $this;
 		$new->created = $created;
 		$new->_touchedFields[static::FIELD_CREATED] = true;
@@ -459,7 +459,7 @@ class ArticleDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withTags(array $tags) {
+	public function withTags(array $tags): static {
 		$new = clone $this;
 		$new->tags = $tags;
 		$new->_touchedFields[static::FIELD_TAGS] = true;
@@ -492,7 +492,7 @@ class ArticleDto extends AbstractImmutableDto {
 	 * @param \TestApp\Dto\TagDto $tag
 	 * @return static
 	 */
-	public function withAddedTag(\TestApp\Dto\TagDto $tag) {
+	public function withAddedTag(\TestApp\Dto\TagDto $tag): static {
 		$new = clone $this;
 
 		if ($new->tags === null) {
@@ -510,7 +510,7 @@ class ArticleDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withMeta(array $meta) {
+	public function withMeta(array $meta): static {
 		$new = clone $this;
 		$new->meta = $meta;
 		$new->_touchedFields[static::FIELD_META] = true;
@@ -536,7 +536,7 @@ class ArticleDto extends AbstractImmutableDto {
 	 *
 	 * @throws \RuntimeException If value with this key is not set.
 	 */
-	public function getMetaValue($key): string {
+	public function getMetaValue(string $key): string {
 		if (!isset($this->meta[$key])) {
 			throw new \RuntimeException(sprintf('Value not set for field `meta` and key `%s` (expected to be not null)', $key));
 		}
@@ -559,7 +559,7 @@ class ArticleDto extends AbstractImmutableDto {
 	 * @param string $key
 	 * @return bool
 	 */
-	public function hasMetaValue($key): bool {
+	public function hasMetaValue(string $key): bool {
 		return isset($this->meta[$key]);
 	}
 
@@ -568,7 +568,7 @@ class ArticleDto extends AbstractImmutableDto {
 	 * @param string $metaValue
 	 * @return static
 	 */
-	public function withAddedMetaValue($key, string $metaValue) {
+	public function withAddedMetaValue(string $key, string $metaValue): static {
 		$new = clone $this;
 
 		if ($new->meta === null) {

--- a/tests/test_app/src/Dto/AuthorDto.php
+++ b/tests/test_app/src/Dto/AuthorDto.php
@@ -46,7 +46,7 @@ class AuthorDto extends AbstractImmutableDto {
 	/**
 	 * @var string|null
 	 */
-	protected $email;
+	protected ?string $email = null;
 
 	/**
 	 * Some data is only for debugging for now.
@@ -180,7 +180,7 @@ class AuthorDto extends AbstractImmutableDto {
 	 *
 	 * @return $this
 	 */
-	protected function setDefaults() {
+	protected function setDefaults(): static {
 
 		return $this;
 	}
@@ -213,7 +213,7 @@ class AuthorDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withId(int $id) {
+	public function withId(int $id): static {
 		$new = clone $this;
 		$new->id = $id;
 		$new->_touchedFields[static::FIELD_ID] = true;
@@ -240,7 +240,7 @@ class AuthorDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withName(string $name) {
+	public function withName(string $name): static {
 		$new = clone $this;
 		$new->name = $name;
 		$new->_touchedFields[static::FIELD_NAME] = true;
@@ -267,7 +267,7 @@ class AuthorDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withEmail(?string $email = null) {
+	public function withEmail(?string $email = null): static {
 		$new = clone $this;
 		$new->email = $email;
 		$new->_touchedFields[static::FIELD_EMAIL] = true;
@@ -280,7 +280,7 @@ class AuthorDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withEmailOrFail(string $email) {
+	public function withEmailOrFail(string $email): static {
 		$new = clone $this;
 		$new->email = $email;
 		$new->_touchedFields[static::FIELD_EMAIL] = true;

--- a/tests/test_app/src/Dto/BookDto.php
+++ b/tests/test_app/src/Dto/BookDto.php
@@ -132,7 +132,7 @@ class BookDto extends AbstractImmutableDto {
 	 *
 	 * @return $this
 	 */
-	protected function setDefaults() {
+	protected function setDefaults(): static {
 
 		return $this;
 	}
@@ -153,7 +153,7 @@ class BookDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withPages(\Cake\Collection\Collection $pages) {
+	public function withPages(\Cake\Collection\Collection $pages): static {
 		$new = clone $this;
 		$new->pages = $pages;
 		$new->_touchedFields[static::FIELD_PAGES] = true;
@@ -186,7 +186,7 @@ class BookDto extends AbstractImmutableDto {
 	 * @param \TestApp\Dto\PageDto $page
 	 * @return static
 	 */
-	public function withAddedPage(\TestApp\Dto\PageDto $page) {
+	public function withAddedPage(\TestApp\Dto\PageDto $page): static {
 		$new = clone $this;
 
 		if ($new->pages === null) {

--- a/tests/test_app/src/Dto/CarDto.php
+++ b/tests/test_app/src/Dto/CarDto.php
@@ -60,37 +60,37 @@ class CarDto extends AbstractDto {
 	/**
 	 * @var \TestApp\ValueObject\Paint|null
 	 */
-	protected $color;
+	protected ?\TestApp\ValueObject\Paint $color = null;
 
 	/**
 	 * @var bool|null
 	 */
-	protected $isNew;
+	protected ?bool $isNew = null;
 
 	/**
 	 * @var float|null
 	 */
-	protected $value;
+	protected ?float $value = null;
 
 	/**
 	 * @var int|null
 	 */
-	protected $distanceTravelled;
+	protected ?int $distanceTravelled = null;
 
 	/**
 	 * @var array<int, string>|null
 	 */
-	protected $attributes;
+	protected ?array $attributes = null;
 
 	/**
 	 * @var \Cake\I18n\Date|null
 	 */
-	protected $manufactured;
+	protected ?\Cake\I18n\Date $manufactured = null;
 
 	/**
 	 * @var \TestApp\Dto\OwnerDto|null
 	 */
-	protected $owner;
+	protected ?\TestApp\Dto\OwnerDto $owner = null;
 
 	/**
 	 * Some data is only for debugging for now.
@@ -329,7 +329,7 @@ class CarDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	protected function setDefaults() {
+	protected function setDefaults(): static {
 
 		return $this;
 	}
@@ -350,7 +350,7 @@ class CarDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setColor(?\TestApp\ValueObject\Paint $color) {
+	public function setColor(?\TestApp\ValueObject\Paint $color): static {
 		$this->color = $color;
 		$this->_touchedFields[static::FIELD_COLOR] = true;
 
@@ -362,7 +362,7 @@ class CarDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setColorOrFail(\TestApp\ValueObject\Paint $color) {
+	public function setColorOrFail(\TestApp\ValueObject\Paint $color): static {
 		$this->color = $color;
 		$this->_touchedFields[static::FIELD_COLOR] = true;
 
@@ -401,7 +401,7 @@ class CarDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setIsNew(?bool $isNew) {
+	public function setIsNew(?bool $isNew): static {
 		$this->isNew = $isNew;
 		$this->_touchedFields[static::FIELD_IS_NEW] = true;
 
@@ -413,7 +413,7 @@ class CarDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setIsNewOrFail(bool $isNew) {
+	public function setIsNewOrFail(bool $isNew): static {
 		$this->isNew = $isNew;
 		$this->_touchedFields[static::FIELD_IS_NEW] = true;
 
@@ -452,7 +452,7 @@ class CarDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setValue(?float $value) {
+	public function setValue(?float $value): static {
 		$this->value = $value;
 		$this->_touchedFields[static::FIELD_VALUE] = true;
 
@@ -464,7 +464,7 @@ class CarDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setValueOrFail(float $value) {
+	public function setValueOrFail(float $value): static {
 		$this->value = $value;
 		$this->_touchedFields[static::FIELD_VALUE] = true;
 
@@ -503,7 +503,7 @@ class CarDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setDistanceTravelled(?int $distanceTravelled) {
+	public function setDistanceTravelled(?int $distanceTravelled): static {
 		$this->distanceTravelled = $distanceTravelled;
 		$this->_touchedFields[static::FIELD_DISTANCE_TRAVELLED] = true;
 
@@ -515,7 +515,7 @@ class CarDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setDistanceTravelledOrFail(int $distanceTravelled) {
+	public function setDistanceTravelledOrFail(int $distanceTravelled): static {
 		$this->distanceTravelled = $distanceTravelled;
 		$this->_touchedFields[static::FIELD_DISTANCE_TRAVELLED] = true;
 
@@ -554,7 +554,7 @@ class CarDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setAttributes(?array $attributes) {
+	public function setAttributes(?array $attributes): static {
 		$this->attributes = $attributes;
 		$this->_touchedFields[static::FIELD_ATTRIBUTES] = true;
 
@@ -566,7 +566,7 @@ class CarDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setAttributesOrFail(array $attributes) {
+	public function setAttributesOrFail(array $attributes): static {
 		$this->attributes = $attributes;
 		$this->_touchedFields[static::FIELD_ATTRIBUTES] = true;
 
@@ -605,7 +605,7 @@ class CarDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setManufactured(?\Cake\I18n\Date $manufactured) {
+	public function setManufactured(?\Cake\I18n\Date $manufactured): static {
 		$this->manufactured = $manufactured;
 		$this->_touchedFields[static::FIELD_MANUFACTURED] = true;
 
@@ -617,7 +617,7 @@ class CarDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setManufacturedOrFail(\Cake\I18n\Date $manufactured) {
+	public function setManufacturedOrFail(\Cake\I18n\Date $manufactured): static {
 		$this->manufactured = $manufactured;
 		$this->_touchedFields[static::FIELD_MANUFACTURED] = true;
 
@@ -656,7 +656,7 @@ class CarDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setOwner(?\TestApp\Dto\OwnerDto $owner) {
+	public function setOwner(?\TestApp\Dto\OwnerDto $owner): static {
 		$this->owner = $owner;
 		$this->_touchedFields[static::FIELD_OWNER] = true;
 
@@ -668,7 +668,7 @@ class CarDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setOwnerOrFail(\TestApp\Dto\OwnerDto $owner) {
+	public function setOwnerOrFail(\TestApp\Dto\OwnerDto $owner): static {
 		$this->owner = $owner;
 		$this->_touchedFields[static::FIELD_OWNER] = true;
 

--- a/tests/test_app/src/Dto/CarsDto.php
+++ b/tests/test_app/src/Dto/CarsDto.php
@@ -132,7 +132,7 @@ class CarsDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	protected function setDefaults() {
+	protected function setDefaults(): static {
 
 		return $this;
 	}
@@ -153,7 +153,7 @@ class CarsDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setCars(\ArrayObject $cars) {
+	public function setCars(\ArrayObject $cars): static {
 		$this->cars = $cars;
 		$this->_touchedFields[static::FIELD_CARS] = true;
 
@@ -178,7 +178,7 @@ class CarsDto extends AbstractDto {
 	 *
 	 * @throws \RuntimeException If value with this key is not set.
 	 */
-	public function getCar($key): \TestApp\Dto\CarDto {
+	public function getCar(string $key): \TestApp\Dto\CarDto {
 		if (!isset($this->cars[$key])) {
 			throw new \RuntimeException(sprintf('Value not set for field `cars` and key `%s` (expected to be not null)', $key));
 		}
@@ -201,7 +201,7 @@ class CarsDto extends AbstractDto {
 	 * @param string $key
 	 * @return bool
 	 */
-	public function hasCar($key): bool {
+	public function hasCar(string $key): bool {
 		return isset($this->cars[$key]);
 	}
 
@@ -210,7 +210,7 @@ class CarsDto extends AbstractDto {
 	 * @param \TestApp\Dto\CarDto $car
 	 * @return $this
 	 */
-	public function addCar($key, \TestApp\Dto\CarDto $car) {
+	public function addCar(string $key, \TestApp\Dto\CarDto $car): static {
 		if ($this->cars === null) {
 			$this->cars = new \ArrayObject([]);
 		}

--- a/tests/test_app/src/Dto/CustomerAccountDto.php
+++ b/tests/test_app/src/Dto/CustomerAccountDto.php
@@ -41,12 +41,12 @@ class CustomerAccountDto extends AbstractDto {
 	/**
 	 * @var int|null
 	 */
-	protected $birthYear;
+	protected ?int $birthYear = null;
 
 	/**
 	 * @var \Cake\I18n\DateTime|null
 	 */
-	protected $lastLogin;
+	protected ?\Cake\I18n\DateTime $lastLogin = null;
 
 	/**
 	 * Some data is only for debugging for now.
@@ -187,7 +187,7 @@ class CustomerAccountDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	protected function setDefaults() {
+	protected function setDefaults(): static {
 
 		return $this;
 	}
@@ -217,7 +217,7 @@ class CustomerAccountDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setCustomerName(string $customerName) {
+	public function setCustomerName(string $customerName): static {
 		$this->customerName = $customerName;
 		$this->_touchedFields[static::FIELD_CUSTOMER_NAME] = true;
 
@@ -243,7 +243,7 @@ class CustomerAccountDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setBirthYear(?int $birthYear) {
+	public function setBirthYear(?int $birthYear): static {
 		$this->birthYear = $birthYear;
 		$this->_touchedFields[static::FIELD_BIRTH_YEAR] = true;
 
@@ -255,7 +255,7 @@ class CustomerAccountDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setBirthYearOrFail(int $birthYear) {
+	public function setBirthYearOrFail(int $birthYear): static {
 		$this->birthYear = $birthYear;
 		$this->_touchedFields[static::FIELD_BIRTH_YEAR] = true;
 
@@ -294,7 +294,7 @@ class CustomerAccountDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setLastLogin(?\Cake\I18n\DateTime $lastLogin) {
+	public function setLastLogin(?\Cake\I18n\DateTime $lastLogin): static {
 		$this->lastLogin = $lastLogin;
 		$this->_touchedFields[static::FIELD_LAST_LOGIN] = true;
 
@@ -306,7 +306,7 @@ class CustomerAccountDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setLastLoginOrFail(\Cake\I18n\DateTime $lastLogin) {
+	public function setLastLoginOrFail(\Cake\I18n\DateTime $lastLogin): static {
 		$this->lastLogin = $lastLogin;
 		$this->_touchedFields[static::FIELD_LAST_LOGIN] = true;
 

--- a/tests/test_app/src/Dto/EmptyOneDto.php
+++ b/tests/test_app/src/Dto/EmptyOneDto.php
@@ -81,7 +81,7 @@ class EmptyOneDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	protected function setDefaults() {
+	protected function setDefaults(): static {
 
 		return $this;
 	}

--- a/tests/test_app/src/Dto/EnumTestDto.php
+++ b/tests/test_app/src/Dto/EnumTestDto.php
@@ -36,17 +36,17 @@ class EnumTestDto extends AbstractImmutableDto {
 	/**
 	 * @var \TestApp\Model\Enum\MyUnit|null
 	 */
-	protected $someUnit;
+	protected ?\TestApp\Model\Enum\MyUnit $someUnit = null;
 
 	/**
 	 * @var \TestApp\Model\Enum\MyStringBacked|null
 	 */
-	protected $someStringBacked;
+	protected ?\TestApp\Model\Enum\MyStringBacked $someStringBacked = null;
 
 	/**
 	 * @var \TestApp\Model\Enum\MyIntBacked|null
 	 */
-	protected $someIntBacked;
+	protected ?\TestApp\Model\Enum\MyIntBacked $someIntBacked = null;
 
 	/**
 	 * Some data is only for debugging for now.
@@ -201,7 +201,7 @@ class EnumTestDto extends AbstractImmutableDto {
 	 *
 	 * @return $this
 	 */
-	protected function setDefaults() {
+	protected function setDefaults(): static {
 
 		return $this;
 	}
@@ -222,7 +222,7 @@ class EnumTestDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withSomeUnit(?\TestApp\Model\Enum\MyUnit $someUnit = null) {
+	public function withSomeUnit(?\TestApp\Model\Enum\MyUnit $someUnit = null): static {
 		$new = clone $this;
 		$new->someUnit = $someUnit;
 		$new->_touchedFields[static::FIELD_SOME_UNIT] = true;
@@ -235,7 +235,7 @@ class EnumTestDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withSomeUnitOrFail(\TestApp\Model\Enum\MyUnit $someUnit) {
+	public function withSomeUnitOrFail(\TestApp\Model\Enum\MyUnit $someUnit): static {
 		$new = clone $this;
 		$new->someUnit = $someUnit;
 		$new->_touchedFields[static::FIELD_SOME_UNIT] = true;
@@ -275,7 +275,7 @@ class EnumTestDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withSomeStringBacked(?\TestApp\Model\Enum\MyStringBacked $someStringBacked = null) {
+	public function withSomeStringBacked(?\TestApp\Model\Enum\MyStringBacked $someStringBacked = null): static {
 		$new = clone $this;
 		$new->someStringBacked = $someStringBacked;
 		$new->_touchedFields[static::FIELD_SOME_STRING_BACKED] = true;
@@ -288,7 +288,7 @@ class EnumTestDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withSomeStringBackedOrFail(\TestApp\Model\Enum\MyStringBacked $someStringBacked) {
+	public function withSomeStringBackedOrFail(\TestApp\Model\Enum\MyStringBacked $someStringBacked): static {
 		$new = clone $this;
 		$new->someStringBacked = $someStringBacked;
 		$new->_touchedFields[static::FIELD_SOME_STRING_BACKED] = true;
@@ -328,7 +328,7 @@ class EnumTestDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withSomeIntBacked(?\TestApp\Model\Enum\MyIntBacked $someIntBacked = null) {
+	public function withSomeIntBacked(?\TestApp\Model\Enum\MyIntBacked $someIntBacked = null): static {
 		$new = clone $this;
 		$new->someIntBacked = $someIntBacked;
 		$new->_touchedFields[static::FIELD_SOME_INT_BACKED] = true;
@@ -341,7 +341,7 @@ class EnumTestDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withSomeIntBackedOrFail(\TestApp\Model\Enum\MyIntBacked $someIntBacked) {
+	public function withSomeIntBackedOrFail(\TestApp\Model\Enum\MyIntBacked $someIntBacked): static {
 		$new = clone $this;
 		$new->someIntBacked = $someIntBacked;
 		$new->_touchedFields[static::FIELD_SOME_INT_BACKED] = true;

--- a/tests/test_app/src/Dto/FlyingCarDto.php
+++ b/tests/test_app/src/Dto/FlyingCarDto.php
@@ -35,7 +35,7 @@ class FlyingCarDto extends CarDto {
 	/**
 	 * @var int|null
 	 */
-	protected $maxAltitude;
+	protected ?int $maxAltitude = null;
 
 	/**
 	 * @var int
@@ -45,7 +45,7 @@ class FlyingCarDto extends CarDto {
 	/**
 	 * @var array|null
 	 */
-	protected $complexAttributes;
+	protected ?array $complexAttributes = null;
 
 	/**
 	 * Some data is only for debugging for now.
@@ -179,7 +179,7 @@ class FlyingCarDto extends CarDto {
 	 *
 	 * @return $this
 	 */
-	protected function setDefaults() {
+	protected function setDefaults(): static {
 		if ($this->maxAltitude === null) {
 			$this->maxAltitude = 0;
 		}
@@ -215,7 +215,7 @@ class FlyingCarDto extends CarDto {
 	 *
 	 * @return $this
 	 */
-	public function setMaxAltitude(?int $maxAltitude) {
+	public function setMaxAltitude(?int $maxAltitude): static {
 		$this->maxAltitude = $maxAltitude;
 		$this->_touchedFields[static::FIELD_MAX_ALTITUDE] = true;
 
@@ -227,7 +227,7 @@ class FlyingCarDto extends CarDto {
 	 *
 	 * @return $this
 	 */
-	public function setMaxAltitudeOrFail(int $maxAltitude) {
+	public function setMaxAltitudeOrFail(int $maxAltitude): static {
 		$this->maxAltitude = $maxAltitude;
 		$this->_touchedFields[static::FIELD_MAX_ALTITUDE] = true;
 
@@ -266,7 +266,7 @@ class FlyingCarDto extends CarDto {
 	 *
 	 * @return $this
 	 */
-	public function setMaxSpeed(int $maxSpeed) {
+	public function setMaxSpeed(int $maxSpeed): static {
 		$this->maxSpeed = $maxSpeed;
 		$this->_touchedFields[static::FIELD_MAX_SPEED] = true;
 
@@ -286,7 +286,7 @@ class FlyingCarDto extends CarDto {
 	 *
 	 * @return $this
 	 */
-	public function setComplexAttributes(?array $complexAttributes) {
+	public function setComplexAttributes(?array $complexAttributes): static {
 		$this->complexAttributes = $complexAttributes;
 		$this->_touchedFields[static::FIELD_COMPLEX_ATTRIBUTES] = true;
 
@@ -298,7 +298,7 @@ class FlyingCarDto extends CarDto {
 	 *
 	 * @return $this
 	 */
-	public function setComplexAttributesOrFail(array $complexAttributes) {
+	public function setComplexAttributesOrFail(array $complexAttributes): static {
 		$this->complexAttributes = $complexAttributes;
 		$this->_touchedFields[static::FIELD_COMPLEX_ATTRIBUTES] = true;
 

--- a/tests/test_app/src/Dto/MutableMetaDto.php
+++ b/tests/test_app/src/Dto/MutableMetaDto.php
@@ -150,7 +150,7 @@ class MutableMetaDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	protected function setDefaults() {
+	protected function setDefaults(): static {
 
 		return $this;
 	}
@@ -180,7 +180,7 @@ class MutableMetaDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setTitle(string $title) {
+	public function setTitle(string $title): static {
 		$this->title = $title;
 		$this->_touchedFields[static::FIELD_TITLE] = true;
 
@@ -206,7 +206,7 @@ class MutableMetaDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setMeta(array $meta) {
+	public function setMeta(array $meta): static {
 		$this->meta = $meta;
 		$this->_touchedFields[static::FIELD_META] = true;
 
@@ -229,7 +229,7 @@ class MutableMetaDto extends AbstractDto {
 	 *
 	 * @return string|null
 	 */
-	public function getMetaValue($key): ?string {
+	public function getMetaValue(string $key): ?string {
 		if (!isset($this->meta[$key])) {
 			return null;
 		}
@@ -252,7 +252,7 @@ class MutableMetaDto extends AbstractDto {
 	 * @param string|null $metaValue
 	 * @return $this
 	 */
-	public function addMetaValue($key, ?string $metaValue) {
+	public function addMetaValue(string $key, ?string $metaValue): static {
 		if ($this->meta === null) {
 			$this->meta = [];
 		}

--- a/tests/test_app/src/Dto/OldOneDto.php
+++ b/tests/test_app/src/Dto/OldOneDto.php
@@ -25,7 +25,7 @@ class OldOneDto extends CarDto {
 	/**
 	 * @var string|null
 	 */
-	protected $name;
+	protected ?string $name = null;
 
 	/**
 	 * Some data is only for debugging for now.
@@ -115,7 +115,7 @@ class OldOneDto extends CarDto {
 	 *
 	 * @return $this
 	 */
-	protected function setDefaults() {
+	protected function setDefaults(): static {
 
 		return $this;
 	}
@@ -136,7 +136,7 @@ class OldOneDto extends CarDto {
 	 *
 	 * @return $this
 	 */
-	public function setName(?string $name) {
+	public function setName(?string $name): static {
 		$this->name = $name;
 		$this->_touchedFields[static::FIELD_NAME] = true;
 
@@ -148,7 +148,7 @@ class OldOneDto extends CarDto {
 	 *
 	 * @return $this
 	 */
-	public function setNameOrFail(string $name) {
+	public function setNameOrFail(string $name): static {
 		$this->name = $name;
 		$this->_touchedFields[static::FIELD_NAME] = true;
 

--- a/tests/test_app/src/Dto/OwnerDto.php
+++ b/tests/test_app/src/Dto/OwnerDto.php
@@ -42,22 +42,22 @@ class OwnerDto extends AbstractDto {
 	/**
 	 * @var string|null
 	 */
-	protected $name;
+	protected ?string $name = null;
 
 	/**
 	 * @var string|null
 	 */
-	protected $insuranceProvider;
+	protected ?string $insuranceProvider = null;
 
 	/**
 	 * @var \TestApp\ValueObject\KeyValuePair|null
 	 */
-	protected $attributes;
+	protected ?\TestApp\ValueObject\KeyValuePair $attributes = null;
 
 	/**
 	 * @var \TestApp\ValueObject\Birthday|null
 	 */
-	protected $birthday;
+	protected ?\TestApp\ValueObject\Birthday $birthday = null;
 
 	/**
 	 * Some data is only for debugging for now.
@@ -226,7 +226,7 @@ class OwnerDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	protected function setDefaults() {
+	protected function setDefaults(): static {
 
 		return $this;
 	}
@@ -247,7 +247,7 @@ class OwnerDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setName(?string $name) {
+	public function setName(?string $name): static {
 		$this->name = $name;
 		$this->_touchedFields[static::FIELD_NAME] = true;
 
@@ -259,7 +259,7 @@ class OwnerDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setNameOrFail(string $name) {
+	public function setNameOrFail(string $name): static {
 		$this->name = $name;
 		$this->_touchedFields[static::FIELD_NAME] = true;
 
@@ -298,7 +298,7 @@ class OwnerDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setInsuranceProvider(?string $insuranceProvider) {
+	public function setInsuranceProvider(?string $insuranceProvider): static {
 		$this->insuranceProvider = $insuranceProvider;
 		$this->_touchedFields[static::FIELD_INSURANCE_PROVIDER] = true;
 
@@ -310,7 +310,7 @@ class OwnerDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setInsuranceProviderOrFail(string $insuranceProvider) {
+	public function setInsuranceProviderOrFail(string $insuranceProvider): static {
 		$this->insuranceProvider = $insuranceProvider;
 		$this->_touchedFields[static::FIELD_INSURANCE_PROVIDER] = true;
 
@@ -349,7 +349,7 @@ class OwnerDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setAttributes(?\TestApp\ValueObject\KeyValuePair $attributes) {
+	public function setAttributes(?\TestApp\ValueObject\KeyValuePair $attributes): static {
 		$this->attributes = $attributes;
 		$this->_touchedFields[static::FIELD_ATTRIBUTES] = true;
 
@@ -361,7 +361,7 @@ class OwnerDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setAttributesOrFail(\TestApp\ValueObject\KeyValuePair $attributes) {
+	public function setAttributesOrFail(\TestApp\ValueObject\KeyValuePair $attributes): static {
 		$this->attributes = $attributes;
 		$this->_touchedFields[static::FIELD_ATTRIBUTES] = true;
 
@@ -400,7 +400,7 @@ class OwnerDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setBirthday(?\TestApp\ValueObject\Birthday $birthday) {
+	public function setBirthday(?\TestApp\ValueObject\Birthday $birthday): static {
 		$this->birthday = $birthday;
 		$this->_touchedFields[static::FIELD_BIRTHDAY] = true;
 
@@ -412,7 +412,7 @@ class OwnerDto extends AbstractDto {
 	 *
 	 * @return $this
 	 */
-	public function setBirthdayOrFail(\TestApp\ValueObject\Birthday $birthday) {
+	public function setBirthdayOrFail(\TestApp\ValueObject\Birthday $birthday): static {
 		$this->birthday = $birthday;
 		$this->_touchedFields[static::FIELD_BIRTHDAY] = true;
 

--- a/tests/test_app/src/Dto/PageDto.php
+++ b/tests/test_app/src/Dto/PageDto.php
@@ -35,7 +35,7 @@ class PageDto extends AbstractImmutableDto {
 	/**
 	 * @var string|null
 	 */
-	protected $content;
+	protected ?string $content = null;
 
 	/**
 	 * Some data is only for debugging for now.
@@ -147,7 +147,7 @@ class PageDto extends AbstractImmutableDto {
 	 *
 	 * @return $this
 	 */
-	protected function setDefaults() {
+	protected function setDefaults(): static {
 
 		return $this;
 	}
@@ -177,7 +177,7 @@ class PageDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withNumber(int $number) {
+	public function withNumber(int $number): static {
 		$new = clone $this;
 		$new->number = $number;
 		$new->_touchedFields[static::FIELD_NUMBER] = true;
@@ -204,7 +204,7 @@ class PageDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withContent(?string $content = null) {
+	public function withContent(?string $content = null): static {
 		$new = clone $this;
 		$new->content = $content;
 		$new->_touchedFields[static::FIELD_CONTENT] = true;
@@ -217,7 +217,7 @@ class PageDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withContentOrFail(string $content) {
+	public function withContentOrFail(string $content): static {
 		$new = clone $this;
 		$new->content = $content;
 		$new->_touchedFields[static::FIELD_CONTENT] = true;

--- a/tests/test_app/src/Dto/TagDto.php
+++ b/tests/test_app/src/Dto/TagDto.php
@@ -180,7 +180,7 @@ class TagDto extends AbstractImmutableDto {
 	 *
 	 * @return $this
 	 */
-	protected function setDefaults() {
+	protected function setDefaults(): static {
 		if ($this->weight === null) {
 			$this->weight = 0;
 		}
@@ -219,7 +219,7 @@ class TagDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withId(int $id) {
+	public function withId(int $id): static {
 		$new = clone $this;
 		$new->id = $id;
 		$new->_touchedFields[static::FIELD_ID] = true;
@@ -246,7 +246,7 @@ class TagDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withName(string $name) {
+	public function withName(string $name): static {
 		$new = clone $this;
 		$new->name = $name;
 		$new->_touchedFields[static::FIELD_NAME] = true;
@@ -273,7 +273,7 @@ class TagDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withWeight(int $weight) {
+	public function withWeight(int $weight): static {
 		$new = clone $this;
 		$new->weight = $weight;
 		$new->_touchedFields[static::FIELD_WEIGHT] = true;

--- a/tests/test_app/src/Dto/TransactionDto.php
+++ b/tests/test_app/src/Dto/TransactionDto.php
@@ -52,7 +52,7 @@ class TransactionDto extends AbstractImmutableDto {
 	/**
 	 * @var string|null
 	 */
-	protected $comment;
+	protected ?string $comment = null;
 
 	/**
 	 * @var \Cake\I18n\Date
@@ -224,7 +224,7 @@ class TransactionDto extends AbstractImmutableDto {
 	 *
 	 * @return $this
 	 */
-	protected function setDefaults() {
+	protected function setDefaults(): static {
 
 		return $this;
 	}
@@ -260,7 +260,7 @@ class TransactionDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withCustomerAccount(\TestApp\Dto\CustomerAccountDto $customerAccount) {
+	public function withCustomerAccount(\TestApp\Dto\CustomerAccountDto $customerAccount): static {
 		$new = clone $this;
 		$new->customerAccount = $customerAccount;
 		$new->_touchedFields[static::FIELD_CUSTOMER_ACCOUNT] = true;
@@ -287,7 +287,7 @@ class TransactionDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withValue(float $value) {
+	public function withValue(float $value): static {
 		$new = clone $this;
 		$new->value = $value;
 		$new->_touchedFields[static::FIELD_VALUE] = true;
@@ -314,7 +314,7 @@ class TransactionDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withComment(?string $comment = null) {
+	public function withComment(?string $comment = null): static {
 		$new = clone $this;
 		$new->comment = $comment;
 		$new->_touchedFields[static::FIELD_COMMENT] = true;
@@ -327,7 +327,7 @@ class TransactionDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withCommentOrFail(string $comment) {
+	public function withCommentOrFail(string $comment): static {
 		$new = clone $this;
 		$new->comment = $comment;
 		$new->_touchedFields[static::FIELD_COMMENT] = true;
@@ -367,7 +367,7 @@ class TransactionDto extends AbstractImmutableDto {
 	 *
 	 * @return static
 	 */
-	public function withCreated(\Cake\I18n\Date $created) {
+	public function withCreated(\Cake\I18n\Date $created): static {
 		$new = clone $this;
 		$new->created = $created;
 		$new->_touchedFields[static::FIELD_CREATED] = true;


### PR DESCRIPTION
## Summary

- Add native typed properties for nullable fields (`protected ?int $id = null`)
- Add `: static` return type to `set*`/`with*`/`add*`/`withAdded*` methods
- Add native `string` parameter type to `$key` in associative collection methods (get/has/add singular)
- Add `: static` return type to `setDefaults()` override in optimizations

### What's NOT typed (and why)

Non-nullable properties (required fields, collection types like `\ArrayObject`) are intentionally left untyped. These are set lazily via `fromArray()`/constructor, so adding a native type would cause "Typed property must not be accessed before initialization" errors.

### BC Note

This is a *minor* BC break: any code that extends generated DTOs and overrides these methods without matching return types will need updating. In practice this is unlikely since DTOs are auto-generated and not intended to be manually subclassed.