### PR TITLE
Make admin UI CSP-compatible (nonce inline scripts)

### DIFF
--- a/templates/Admin/Generate/database.php
+++ b/templates/Admin/Generate/database.php
@@ -8,6 +8,7 @@
  * @var mixed $result
  * @var mixed $schema
  */
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <h1>Generate DTO Schema from Database Tables</h1>
 
@@ -50,7 +51,7 @@
 		</button>
 		<pre id="result-code" class="pt-5"><?php echo h($result); ?></pre>
 	</div>
-	<script>
+	<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 	document.getElementById('copy-btn').addEventListener('click', function() {
 		var code = document.getElementById('result-code').textContent;
 		var btn = document.getElementById('copy-btn');
@@ -152,7 +153,7 @@
 	<?php echo $this->Form->button('Parse Selected Tables'); ?>
 	<?php echo $this->Form->end(); ?>
 
-	<script>
+	<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 	document.getElementById('select-all').addEventListener('change', function() {
 		var checkboxes = document.querySelectorAll('.table-checkbox');
 		for (var i = 0; i < checkboxes.length; i++) {

--- a/templates/Admin/Generate/schema.php
+++ b/templates/Admin/Generate/schema.php
@@ -7,6 +7,7 @@
  * @var mixed $result
  * @var mixed $schema
  */
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <h1>Generate DTO Schema from JSON/Structure</h1>
 
@@ -49,7 +50,7 @@
 		</button>
 		<pre id="result-code" class="pt-5"><?php echo h($result); ?></pre>
 	</div>
-	<script>
+	<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 	document.getElementById('copy-btn').addEventListener('click', function() {
 		var code = document.getElementById('result-code').textContent;
 		var btn = document.getElementById('copy-btn');
@@ -147,7 +148,7 @@
 
 	<?php if ($compressed) { ?>
 	<?php echo $this->Html->script('https://cdnjs.cloudflare.com/ajax/libs/pako/2.1.0/pako.min.js'); ?>
-	<script>
+	<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 	document.addEventListener('DOMContentLoaded', function() {
 		var field = document.getElementById('input-field');
 		var compressed = field.dataset.compressed;


### PR DESCRIPTION
## Summary

- Add nonce attribute to 4 inline `<script>` blocks across the two admin generator templates (`schema.php` and `database.php`).

## Motivation

Under a strict Content-Security-Policy with `script-src 'self' 'nonce-...'`, inline `<script>` blocks without `nonce` are blocked by the browser. The plugin's admin generator templates already use addEventListener (no inline event handlers), so only the nonce attribute needs to be added.

## Changes

- Add `nonce` to 4 inline `<script>` blocks:
  - `templates/Admin/Generate/schema.php` (copy-to-clipboard, decompress)
  - `templates/Admin/Generate/database.php` (copy-to-clipboard, select-all checkbox)

No `postLink` calls, no inline event-handler attributes, no layout changes. Scripts fall back to rendering without `nonce` when the host app does not set a `cspNonce` request attribute.

## Host app nonce setup

Apps that want to benefit need to set a `cspNonce` request attribute in a middleware, e.g.:

```php
$nonce = base64_encode(random_bytes(16));
$request = $request->withAttribute('cspNonce', $nonce);
$response = $response->withHeader(
    'Content-Security-Policy',
    "script-src 'self' 'nonce-{$nonce}'"
);
```

If no `cspNonce` attribute is present, the `<script>` tag falls back to rendering without `nonce` — apps on permissive CSP continue to work unchanged.

## Before / after

```diff
+ <?php $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', ''); ?>
...
- <script>
+ <script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
```
