### PR TITLE
Ship plugin admin AppController with default-deny access gate

### DIFF
--- a/docs/Generating.md
+++ b/docs/Generating.md
@@ -7,6 +7,18 @@ In this case, you can either write them manually, or let a tool convert it for y
 
 The plugin provides a web-based interface for generating DTO definitions from JSON data. This is particularly useful for quickly converting API responses or existing data structures into DTO schemas.
 
+**Configuring access:**
+The admin UI introspects your application's database schema and generates files, so it is **default-deny** — every request returns 403 unless `CakeDto.adminAccess` is set to a `Closure` that returns literal `true`. Configure it in your `config/app.php` or `config/bootstrap.php`:
+
+```php
+Configure::write('CakeDto.adminAccess', function (\Cake\Http\ServerRequest $request): bool {
+    $identity = $request->getAttribute('identity');
+    return $identity !== null && in_array('admin', (array)$identity->roles, true);
+});
+```
+
+The Closure receives the current `ServerRequest`. Anything other than a literal `true` return value (false, truthy non-bool, null, or an exception) yields a 403, so the gate fails closed.
+
 **Accessing the UI:**
 Navigate to `/admin/cake-dto/generate` in your browser. This route is provided by the plugin and includes:
 

--- a/src/Controller/Admin/AppController.php
+++ b/src/Controller/Admin/AppController.php
@@ -1,0 +1,104 @@
+<?php
+declare(strict_types=1);
+
+namespace CakeDto\Controller\Admin;
+
+use Cake\Controller\Controller;
+use Cake\Core\Configure;
+use Cake\Event\EventInterface;
+use Cake\Http\Exception\ForbiddenException;
+use Cake\Log\Log;
+use Closure;
+use Throwable;
+
+/**
+ * Base controller for CakeDto Admin controllers.
+ *
+ * The admin UI introspects the application's database schema and writes
+ * generated DTO files, so accidental exposure to anonymous users is a
+ * serious problem. The default policy is therefore **deny**. The host
+ * application MUST set `CakeDto.adminAccess` to a `Closure` that receives
+ * the current request and returns literal `true` to grant access; anything
+ * else (unset, non-Closure, returns false, returns a truthy non-bool, or
+ * throws) yields a 403.
+ *
+ * ```php
+ * Configure::write('CakeDto.adminAccess', function (\Cake\Http\ServerRequest $request): bool {
+ *     $identity = $request->getAttribute('identity');
+ *     return $identity !== null && in_array('admin', (array)$identity->roles, true);
+ * });
+ * ```
+ *
+ * Subclasses do not need to opt out of authentication / authorization
+ * components: this gate is the authorization decision for the admin UI,
+ * and the `Authorization` component policy check is silenced here so
+ * controllers do not have to call `skipAuthorization()` themselves.
+ */
+class AppController extends Controller {
+
+	/**
+	 * Default-deny access gate.
+	 *
+	 * @param \Cake\Event\EventInterface<\Cake\Controller\Controller> $event
+	 * @throws \Cake\Http\Exception\ForbiddenException When access is denied or unconfigured.
+	 * @return void
+	 */
+	public function beforeFilter(EventInterface $event): void {
+		parent::beforeFilter($event);
+
+		// Coexist with cakephp/authorization: this gate IS the authorization
+		// decision for the CakeDto admin, so silence the policy check.
+		if ($this->components()->has('Authorization') && method_exists($this->components()->get('Authorization'), 'skipAuthorization')) {
+			$this->components()->get('Authorization')->skipAuthorization();
+		}
+
+		$adminAccess = Configure::read('CakeDto.adminAccess');
+		if ($adminAccess instanceof Closure) {
+			$request = $this->request;
+			$this->runGate(static fn (): mixed => $adminAccess($request));
+
+			return;
+		}
+		if ($adminAccess !== null) {
+			throw new ForbiddenException('CakeDto.adminAccess must be a Closure');
+		}
+
+		throw new ForbiddenException(
+			'CakeDto admin UI is not configured. Set CakeDto.adminAccess to a Closure that returns true for permitted callers.',
+		);
+	}
+
+	/**
+	 * Run the gate Closure, normalising every non-true outcome to a 403 and
+	 * logging unexpected exceptions instead of leaking them to the client.
+	 *
+	 * @param \Closure $gate
+	 * @throws \Cake\Http\Exception\ForbiddenException
+	 * @return void
+	 */
+	private function runGate(Closure $gate): void {
+		try {
+			$allowed = $gate() === true;
+		} catch (ForbiddenException $e) {
+			// Caller explicitly chose the 403 path - respect it.
+			throw $e;
+		} catch (Throwable $e) {
+			// Convert any other failure (broken callable, transient DB
+			// error in a role lookup, etc.) to a generic 403. Logging the
+			// concrete exception class + message lets operators diagnose
+			// it without leaking a stack trace to the client.
+			Log::warning(sprintf(
+				'CakeDto admin gate threw %s: %s',
+				$e::class,
+				$e->getMessage(),
+			));
+
+			throw new ForbiddenException('Not authorized to access CakeDto admin UI');
+		}
+
+		if (!$allowed) {
+			throw new ForbiddenException('Not authorized to access CakeDto admin UI');
+		}
+	}
+
+}

--- a/src/Controller/Admin/GenerateController.php
+++ b/src/Controller/Admin/GenerateController.php
@@ -1,30 +1,13 @@
 <?php
+declare(strict_types=1);
 
 namespace CakeDto\Controller\Admin;
 
-use App\Controller\AppController;
-use Cake\Event\EventInterface;
 use CakeDto\Importer\DatabaseParser;
 use Exception;
 use PhpCollective\Dto\Importer\Importer;
 
 class GenerateController extends AppController {
-
-	/**
-	 * @param \Cake\Event\EventInterface $event
-	 *
-	 * @return void
-	 */
-	public function beforeFilter(EventInterface $event): void {
-		if ($this->components()->has('Auth') && method_exists($this->components()->get('Auth'), 'allow')) {
-			$this->components()->get('Auth')->allow();
-		} elseif ($this->components()->has('Authentication') && method_exists($this->components()->get('Authentication'), 'addUnauthenticatedActions')) {
-			$this->components()->get('Authentication')->addUnauthenticatedActions(['display']);
-		}
-		if ($this->components()->has('Authorization') && method_exists($this->components()->get('Authorization'), 'skipAuthorization')) {
-			$this->components()->get('Authorization')->skipAuthorization();
-		}
-	}
 
 	/**
 	 * @return void

--- a/src/Controller/DtoControllerFactory.php
+++ b/src/Controller/DtoControllerFactory.php
@@ -200,11 +200,4 @@ class DtoControllerFactory extends ControllerFactory {
 		return $request->getQueryParams();
 	}
 
-	/**
-	 * @param \ReflectionParameter $parameter
-	 * @param array $passedParams
-	 *
-	 * @return mixed
-	 */
-
 }

--- a/tests/TestCase/Controller/Admin/GenerateControllerTest.php
+++ b/tests/TestCase/Controller/Admin/GenerateControllerTest.php
@@ -3,9 +3,11 @@ declare(strict_types=1);
 
 namespace CakeDto\Test\TestCase\Controller\Admin;
 
+use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlite;
 use Cake\Datasource\ConnectionManager;
+use Cake\Http\Exception\ForbiddenException;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 
@@ -24,6 +26,15 @@ class GenerateControllerTest extends TestCase {
 
 		$this->loadPlugins(['CakeDto']);
 		$this->disableErrorHandlerMiddleware();
+		Configure::write('CakeDto.adminAccess', fn (): bool => true);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function tearDown(): void {
+		Configure::delete('CakeDto.adminAccess');
+		parent::tearDown();
 	}
 
 	/**
@@ -96,6 +107,42 @@ class GenerateControllerTest extends TestCase {
 		$this->assertResponseContains('title');
 
 		ConnectionManager::drop('default');
+	}
+
+	/**
+	 * Default-deny: with `CakeDto.adminAccess` unset, the gate must reject every admin request.
+	 *
+	 * @return void
+	 */
+	public function testIndexDeniedByDefault(): void {
+		Configure::delete('CakeDto.adminAccess');
+		$this->expectException(ForbiddenException::class);
+
+		$this->get(['prefix' => 'Admin', 'plugin' => 'CakeDto', 'controller' => 'Generate', 'action' => 'index']);
+	}
+
+	/**
+	 * A non-Closure value for the gate config must also be rejected.
+	 *
+	 * @return void
+	 */
+	public function testIndexDeniedWhenAdminAccessIsNotAClosure(): void {
+		Configure::write('CakeDto.adminAccess', true);
+		$this->expectException(ForbiddenException::class);
+
+		$this->get(['prefix' => 'Admin', 'plugin' => 'CakeDto', 'controller' => 'Generate', 'action' => 'index']);
+	}
+
+	/**
+	 * A Closure that returns a non-true value (false, truthy non-bool, null) must be rejected.
+	 *
+	 * @return void
+	 */
+	public function testIndexDeniedWhenClosureReturnsNonTrue(): void {
+		Configure::write('CakeDto.adminAccess', fn (): bool => false);
+		$this->expectException(ForbiddenException::class);
+
+		$this->get(['prefix' => 'Admin', 'plugin' => 'CakeDto', 'controller' => 'Generate', 'action' => 'index']);
 	}
 
 }


### PR DESCRIPTION
## Summary

The admin UI under `Admin/Generate` introspects the host application's database schema and writes generated DTO files. The previous setup made this easy to misconfigure into an open endpoint:

- `GenerateController` extended `App\Controller\AppController`, hard-coupling the plugin to the host app's namespace and breaking on any app that has not yet declared that class (or uses a non-default namespace).
- The same controller's `beforeFilter()` opted out of any plugin-level authentication and authorization (`Auth->allow()`, `Authentication->addUnauthenticatedActions(['display'])` — note the dead `display` action that does not exist on this controller — and `Authorization->skipAuthorization()`). Anyone reaching the admin route could `POST` arbitrary JSON to `schema()` and read every table name in the configured connection via `database()`.

This PR replaces both with a queue-style **default-deny** access gate.

### Changes

- **New `src/Controller/Admin/AppController.php`** — plugin-owned base controller. `beforeFilter()` reads `CakeDto.adminAccess`; only a `Closure` returning literal `true` grants access. Anything else (unset, non-Closure, returns false, returns truthy non-bool, or throws) yields a 403. Throwables are logged with class + message and normalised so stack traces never leak to the client. The `Authorization` component policy check is silenced once here so subclasses do not have to reimplement it.
- **`GenerateController`** now extends the new base, drops its own `beforeFilter()` entirely (and with it the stale `display` action list and the auth/authz opt-outs), and gains `declare(strict_types=1)`.
- **Tests** — existing controller tests write `CakeDto.adminAccess` in `setUp()` and delete it in `tearDown()`. Added three default-deny regression tests: unset, non-Closure value, and Closure returning false.
- **`docs/Generating.md`** documents the configuration knob so the gate is discoverable before the first 403.
- **Cleanup** — removed an orphan docblock at the bottom of `src/Controller/DtoControllerFactory.php` left over from an earlier method removal.

### Required configuration for upgraders

The admin UI at `/admin/cake-dto/generate` now requires explicit configuration before it will respond. Add the following to your `config/app.php` or `config/bootstrap.php`:

```php
Configure::write('CakeDto.adminAccess', function (\Cake\Http\ServerRequest $request): bool {
    $identity = $request->getAttribute('identity');
    return $identity !== null && in_array('admin', (array)$identity->roles, true);
});
```

The Closure receives the current `ServerRequest`. Anything other than a literal `true` return value yields a 403, so the gate fails closed.

### Verification

- `vendor/bin/phpunit` — 213 tests passing (3 new).
- `vendor/bin/phpstan analyze --no-progress` — clean.
- `vendor/bin/phpcs src/` — clean.