### PR TITLE
Fix CS in app.example.php

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -1,5 +1,7 @@
 <?php
 
+use Cake\Http\ServerRequest;
+
 // The following configs can be globally configured, copy the array content over to your ROOT/config/app.php
 
 return [
@@ -13,9 +15,10 @@ return [
 		'defaultCollectionType' => null, // Defaults to `\ArrayObject`
 		'debug' => false, // Add all meta data into DTOs for debugging
 		'keyType' => null, // Dto::TYPE_DEFAULT by default which uses Dto::TYPE_CAMEL
-		'adminAccess' => function (\Cake\Http\ServerRequest $request): bool {
+		'adminAccess' => function (ServerRequest $request): bool {
 			// Default-deny gate for /admin/cake-dto/generate. Must return literal `true` to grant access.
 			$identity = $request->getAttribute('identity');
+
 			return $identity !== null && in_array('admin', (array)$identity->roles, true);
 		},
 	],


### PR DESCRIPTION
## Summary

Master CI is currently red because `config/app.example.php` lines 16/19 trip two autofixable CS rules introduced by commit 28b46f3 ("Add CakeDto.adminAccess example to app.example.php"):

- `SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName` — `\Cake\Http\ServerRequest` referenced via FQN inside the closure signature.
- `SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing.IncorrectLinesCountBeforeControlStructure` — missing blank line before the `return` in the closure body.

Both autofixable. Adds the `use Cake\Http\ServerRequest;` import and the blank line before the return. No behavior change.

`vendor/bin/phpcs config/app.example.php` is clean locally; `php -l` passes.