### PR TITLE
Drop stray __d('debug_kit', ...) call in DebugTimer

### DIFF
--- a/src/TestSuite/DebugTimer.php
+++ b/src/TestSuite/DebugTimer.php
@@ -128,7 +128,7 @@ class DebugTimer {
 			$_end = $now;
 		}
 		$times['Core Processing (Derived from $_SERVER["REQUEST_TIME"])'] = [
-			'message' => __d('debug_kit', 'Core Processing (Derived from $_SERVER["REQUEST_TIME"])'),
+			'message' => 'Core Processing (Derived from $_SERVER["REQUEST_TIME"])',
 			'start' => 0,
 			'end' => $_end - $start,
 			'time' => round($_end - $start, 6),


### PR DESCRIPTION
## Summary

- Drop the lone `__d('debug_kit', ...)` call in `src/TestSuite/DebugTimer.php`. It was a leftover from when the class was copied verbatim from `cakephp/debug_kit`.
- Replace with a plain string literal — matches the file's own pattern (every other timer message in the class uses a raw caller-supplied string with no translation), and the "Core Processing..." label only ever appears in test/debug timer output.

No domain switch — chose to remove the call rather than re-route to a `dto` domain because (a) it would be the only translated string in the plugin, (b) shipping a POT for one diagnostic label is overkill, and (c) the surrounding code clearly didn't intend to translate timer labels.

## Why

The string was landing in `cakephp/debug_kit`'s translation domain. That only resolved if DebugKit was installed in the host app, and it would have been wrong even then — `cakephp-dto` is not DebugKit.

## Verification (local)

- phpunit: 211 / 211 (20 pre-existing notices, unrelated)
- phpstan: no errors
- phpcs: clean