### PR TITLE
Fix DatabaseParser type defaults, DtoMapper type loss, Generator path regex

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -8,6 +8,7 @@ return [
 	'CakeDto' => [
 		'engine' => null, // Defaults to `XmlEngine`. Can be your custom yml, neon, ... engine
 		'suffix' => 'Dto', // Class name suffix (recommended)
+		'srcPath' => null, // Defaults to `SRC`, e.g. `ROOT . DS . 'generated' . DS` for separated generated code
 		'strictTypes' => false, // This can create casting requirement
 		'scalarAndReturnTypes' => true,
 		'typedConstants' => false, // Requires PHP 8.3+ for typed class constants
@@ -15,6 +16,22 @@ return [
 		'defaultCollectionType' => null, // Defaults to `\ArrayObject`
 		'debug' => false, // Add all meta data into DTOs for debugging
 		'keyType' => null, // Dto::TYPE_DEFAULT by default which uses Dto::TYPE_CAMEL
+		'assocKeyFields' => ['slug', 'login', 'name'], // Candidate keys when inferring associative collections from example JSON
+		'databaseTypeMap' => [
+			// `decimal` intentionally defaults to `string` in the importer to avoid precision loss.
+			// Uncomment to restore the pre-2.10 behavior if your generated DTOs still expect float:
+			// 'decimal' => 'float',
+			// Or opt into a project-specific value object type, e.g. for cakephp-decimal:
+			// 'decimal' => '\PhpCollective\DecimalObject\Decimal',
+
+			// `json` stays `array` by default for generation-output BC in the current release line.
+			// Uncomment to opt into schema-honest JSON typing instead:
+			// 'json' => 'mixed',
+		],
+		'finder' => null, // Defaults to the php-collective/dto Finder class
+		'builder' => null, // Defaults to `CakeDto\Generator\Builder`
+		'generator' => null, // Defaults to `CakeDto\Generator\Generator`
+		'renderer' => null, // Defaults to `CakeDto\View\Renderer`
 		'adminAccess' => function (ServerRequest $request): bool {
 			// Default-deny gate for /admin/cake-dto/generate. Must return literal `true` to grant access.
 			$identity = $request->getAttribute('identity');

--- a/docs/Generating.md
+++ b/docs/Generating.md
@@ -57,6 +57,45 @@ Best to check and fine tune your DTO schema afterwards.
 
 ### Tips and useful notes
 
+#### Database import type defaults
+When generating DTO definitions from your database schema, the plugin maps CakePHP
+column types to DTO field types using `CakeDto\Importer\DatabaseParser`.
+
+Current defaults of note:
+- `decimal` => `string`
+- `json` => `array`
+
+The `decimal` change is an intentional generation-output BC break in the current
+minor line. The previous `float` default was convenient, but wrong for exact decimal
+storage because it silently reintroduced precision loss into generated DTOs. Cake's
+ORM already hydrates decimal columns as strings by default, so the importer now
+matches the runtime data shape instead of a lossy convenience type.
+
+If you need the former behavior for an incremental upgrade, restore it explicitly:
+
+```php
+Configure::write('CakeDto.databaseTypeMap', [
+    'decimal' => 'float',
+]);
+```
+
+If your project uses a custom value object instead, opt in explicitly:
+
+```php
+Configure::write('CakeDto.databaseTypeMap', [
+    'decimal' => '\PhpCollective\DecimalObject\Decimal',
+]);
+```
+
+`json` intentionally remains `array` in the current release line for backward
+compatibility. Projects that prefer schema-honest JSON typing can override it:
+
+```php
+Configure::write('CakeDto.databaseTypeMap', [
+    'json' => 'mixed',
+]);
+```
+
 #### Associative collections
 You want to look into associative collections. In some cases you can - after parsing -
   adjust the schema field definitions to set a "key" for the associative array/object collection.

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,9 @@ use PhpCollective\Dto\Engine\PhpEngine;
 ]
 ```
 
+For the full plugin config surface, including `databaseTypeMap`, `assocKeyFields`,
+admin access, and generator overrides, see [`config/app.example.php`](../config/app.example.php).
+
 YAML or alike might have the advantage of less typing, but the power of XML comes with its XSD validation and full auto-complete/typehinting.
 Just start typing and you will see how it already gives you all the options to chose from.
 

--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -132,21 +132,34 @@ class Generator {
 	 * @return array<string>
 	 */
 	protected function findExistingDtos(string $path): array {
-		if (!is_dir($path)) {
-			mkdir($path, 0755, true);
+		if (!is_dir($path) && @mkdir($path, 0755, true) === false && !is_dir($path)) {
+			// Either the path exists as a file (a real misconfiguration) or
+			// the filesystem rejected the mkdir. Bail with an empty result
+			// instead of letting a later `is_dir` failure cascade through
+			// the iterator — the caller will surface a useful error.
+			return [];
 		}
 
 		$files = [];
 
 		$directory = new RecursiveDirectoryIterator($path);
 		$iterator = new RecursiveIteratorIterator($directory);
+		$suffix = Configure::read('CakeDto.suffix', 'Dto');
+		// Use DIRECTORY_SEPARATOR via a character class so the pattern matches
+		// on both `src/Dto/Foo.php` (Linux/macOS) and `src\Dto\Foo.php` (Windows).
+		// The previous `#src/Dto/(.+)...#` hardcoded forward slashes, so the
+		// "find existing DTOs to delete" pass silently returned nothing on
+		// Windows and left stale files behind.
+		$pattern = '#[/\\\\]src[/\\\\]Dto[/\\\\](.+)' . preg_quote($suffix, '#') . '\.php$#';
 		foreach ($iterator as $fileInfo) {
 			$file = $fileInfo->getPathname();
-			$suffix = Configure::read('CakeDto.suffix', 'Dto');
-			if (!preg_match('#src/Dto/(.+)' . $suffix . '\.php$#', $file, $matches)) {
+			if (!preg_match($pattern, $file, $matches)) {
 				continue;
 			}
 			$name = $matches[1];
+			// Normalize captured nested paths so "Sub/Foo" and "Sub\\Foo"
+			// don't both land in the result map as separate entries.
+			$name = strtr($name, '\\', '/');
 			$files[$name] = $file;
 		}
 

--- a/src/Importer/DatabaseParser.php
+++ b/src/Importer/DatabaseParser.php
@@ -10,11 +10,13 @@ use Cake\Utility\Inflector;
 class DatabaseParser {
 
 	/**
-	 * Defaults are precision-safe and dependency-free:
+	 * Defaults are precision-safe and dependency-aware:
 	 *
 	 * - `decimal` maps to `string` instead of `float`. Mapping to `float`
 	 *   reintroduces the precision loss that decimal columns exist to
-	 *   prevent. We don't default to a value-object like
+	 *   prevent. This is an intentional generation-output BC break in a
+	 *   bugfix release line: the previous `float` default was convenient,
+	 *   but wrong for exact decimal storage. We don't default to a value-object like
 	 *   `\PhpCollective\DecimalObject\Decimal` because cakephp-dto does
 	 *   not require that package — generating a DTO referencing a class
 	 *   that may not be installed is a worse failure mode than the
@@ -22,18 +24,19 @@ class DatabaseParser {
 	 *   decimal columns as strings by default, so this aligns with what
 	 *   the entity layer hands you. Apps using cakephp-decimal can opt in
 	 *   via the Configure override below.
-	 * - `json` maps to `mixed` instead of `array`. A JSON column may hold a
-	 *   single object, a scalar, or an array, and forcing `array` strips
-	 *   that information at the type level. `mixed` lets the generated DTO
-	 *   round-trip whatever the column actually contains.
+	 * - `json` stays `array` for backward compatibility in the current major/minor
+	 *   line. Applications that need schema-honest typing for scalar/object JSON
+	 *   payloads can override this to `mixed` (or a project-specific DTO/value
+	 *   object type) via Configure.
 	 *
 	 * Apps that prefer different shapes override entry-by-entry via
 	 * `Configure::write('CakeDto.databaseTypeMap', [...])`, e.g.:
 	 *
 	 * ```php
 	 * Configure::write('CakeDto.databaseTypeMap', [
-	 *     'decimal' => '\PhpCollective\DecimalObject\Decimal',  // for cakephp-decimal users
-	 *     'json'    => 'array',                                  // pre-fix behavior
+	 *     'decimal' => 'float', // restore pre-fix behavior
+	 *     'json' => 'mixed', // opt into schema-honest JSON typing
+	 *     // or: 'decimal' => '\PhpCollective\DecimalObject\Decimal', // for cakephp-decimal users
 	 * ]);
 	 * ```
 	 *
@@ -58,7 +61,7 @@ class DatabaseParser {
 		'timestampfractional' => '\Cake\I18n\DateTime',
 		'timestamptimezone' => '\Cake\I18n\DateTime',
 		'time' => '\Cake\I18n\Time',
-		'json' => 'mixed',
+		'json' => 'array',
 		'binary' => 'string',
 	];
 

--- a/src/Importer/DatabaseParser.php
+++ b/src/Importer/DatabaseParser.php
@@ -10,20 +10,32 @@ use Cake\Utility\Inflector;
 class DatabaseParser {
 
 	/**
-	 * Defaults are now precision-and-shape-friendly:
+	 * Defaults are precision-safe and dependency-free:
 	 *
-	 * - `decimal` maps to `\PhpCollective\DecimalObject\Decimal` instead of
-	 *   `float`. Mapping to `float` re-introduces the precision loss that
-	 *   cakephp-decimal (a common Cake companion plugin) exists to solve.
+	 * - `decimal` maps to `string` instead of `float`. Mapping to `float`
+	 *   reintroduces the precision loss that decimal columns exist to
+	 *   prevent. We don't default to a value-object like
+	 *   `\PhpCollective\DecimalObject\Decimal` because cakephp-dto does
+	 *   not require that package — generating a DTO referencing a class
+	 *   that may not be installed is a worse failure mode than the
+	 *   precision-safe `string` fallback. Cake's ORM already returns
+	 *   decimal columns as strings by default, so this aligns with what
+	 *   the entity layer hands you. Apps using cakephp-decimal can opt in
+	 *   via the Configure override below.
 	 * - `json` maps to `mixed` instead of `array`. A JSON column may hold a
 	 *   single object, a scalar, or an array, and forcing `array` strips
 	 *   that information at the type level. `mixed` lets the generated DTO
 	 *   round-trip whatever the column actually contains.
 	 *
-	 * Apps that prefer the old `float`/`array` behavior — or that don't use
-	 * cakephp-decimal — can override the map entry-by-entry with
-	 * `Configure::write('CakeDto.databaseTypeMap', ['decimal' => 'float', 'json' => 'array'])`,
-	 * or per-entry shorter forms.
+	 * Apps that prefer different shapes override entry-by-entry via
+	 * `Configure::write('CakeDto.databaseTypeMap', [...])`, e.g.:
+	 *
+	 * ```php
+	 * Configure::write('CakeDto.databaseTypeMap', [
+	 *     'decimal' => '\PhpCollective\DecimalObject\Decimal',  // for cakephp-decimal users
+	 *     'json'    => 'array',                                  // pre-fix behavior
+	 * ]);
+	 * ```
 	 *
 	 * @var array<string, string>
 	 */
@@ -38,7 +50,7 @@ class DatabaseParser {
 		'uuid' => 'string',
 		'boolean' => 'bool',
 		'float' => 'float',
-		'decimal' => '\PhpCollective\DecimalObject\Decimal',
+		'decimal' => 'string',
 		'date' => '\Cake\I18n\Date',
 		'datetime' => '\Cake\I18n\DateTime',
 		'timestamp' => '\Cake\I18n\DateTime',

--- a/src/Importer/DatabaseParser.php
+++ b/src/Importer/DatabaseParser.php
@@ -2,6 +2,7 @@
 
 namespace CakeDto\Importer;
 
+use Cake\Core\Configure;
 use Cake\Database\Schema\TableSchemaInterface;
 use Cake\Datasource\ConnectionManager;
 use Cake\Utility\Inflector;
@@ -9,6 +10,21 @@ use Cake\Utility\Inflector;
 class DatabaseParser {
 
 	/**
+	 * Defaults are now precision-and-shape-friendly:
+	 *
+	 * - `decimal` maps to `\PhpCollective\DecimalObject\Decimal` instead of
+	 *   `float`. Mapping to `float` re-introduces the precision loss that
+	 *   cakephp-decimal (a common Cake companion plugin) exists to solve.
+	 * - `json` maps to `mixed` instead of `array`. A JSON column may hold a
+	 *   single object, a scalar, or an array, and forcing `array` strips
+	 *   that information at the type level. `mixed` lets the generated DTO
+	 *   round-trip whatever the column actually contains.
+	 *
+	 * Apps that prefer the old `float`/`array` behavior — or that don't use
+	 * cakephp-decimal — can override the map entry-by-entry with
+	 * `Configure::write('CakeDto.databaseTypeMap', ['decimal' => 'float', 'json' => 'array'])`,
+	 * or per-entry shorter forms.
+	 *
 	 * @var array<string, string>
 	 */
 	protected array $typeMap = [
@@ -22,7 +38,7 @@ class DatabaseParser {
 		'uuid' => 'string',
 		'boolean' => 'bool',
 		'float' => 'float',
-		'decimal' => 'float',
+		'decimal' => '\PhpCollective\DecimalObject\Decimal',
 		'date' => '\Cake\I18n\Date',
 		'datetime' => '\Cake\I18n\DateTime',
 		'timestamp' => '\Cake\I18n\DateTime',
@@ -30,9 +46,21 @@ class DatabaseParser {
 		'timestampfractional' => '\Cake\I18n\DateTime',
 		'timestamptimezone' => '\Cake\I18n\DateTime',
 		'time' => '\Cake\I18n\Time',
-		'json' => 'array',
+		'json' => 'mixed',
 		'binary' => 'string',
 	];
+
+	public function __construct() {
+		// Allow opt-in overrides without subclassing.
+		$overrides = Configure::read('CakeDto.databaseTypeMap');
+		if (is_array($overrides)) {
+			foreach ($overrides as $cakeType => $dtoType) {
+				if (is_string($cakeType) && is_string($dtoType)) {
+					$this->typeMap[$cakeType] = $dtoType;
+				}
+			}
+		}
+	}
 
 	/**
 	 * @param string $connectionName

--- a/src/Mapper/DtoMapper.php
+++ b/src/Mapper/DtoMapper.php
@@ -23,7 +23,49 @@ class DtoMapper {
 	public static function fromEntity(EntityInterface $entity, string $dtoClass, bool $ignoreMissing = false, ?string $type = null): Dto {
 		static::assertDtoClass($dtoClass);
 
-		return $dtoClass::createFromArray($entity->toArray(), $ignoreMissing, $type);
+		return $dtoClass::createFromArray(static::extractEntity($entity), $ignoreMissing, $type);
+	}
+
+	/**
+	 * Flatten an entity to an associative array, preserving scalar value
+	 * objects (Decimal, DateTime, custom VOs) but unwrapping nested entities
+	 * one level at a time so the DTO library can recursively rebuild nested
+	 * DTOs.
+	 *
+	 * Cake's `EntityInterface::toArray()` arraifies nested entities AND
+	 * strips object-typed values along the way — fine for JSON, wrong for
+	 * DTO mapping because a typed `Decimal $price` field then gets a string
+	 * from the DTO constructor and either re-coerces (slow) or fails
+	 * type-check. The previous implementation lost Decimal/DateTime/Chronos
+	 * types on every save.
+	 *
+	 * The hybrid approach below: `extract(getVisible())` for value preservation,
+	 * then explicitly arraify EntityInterface values (and arrays of them) so
+	 * the DTO library still has the recursive shape it expects for nested
+	 * typed DTO properties.
+	 *
+	 * @param \Cake\Datasource\EntityInterface $entity
+	 * @return array<string, mixed>
+	 */
+	protected static function extractEntity(EntityInterface $entity): array {
+		$out = $entity->extract($entity->getVisible());
+		foreach ($out as $field => $value) {
+			if ($value instanceof EntityInterface) {
+				$out[$field] = static::extractEntity($value);
+
+				continue;
+			}
+			if (is_array($value)) {
+				foreach ($value as $k => $inner) {
+					if ($inner instanceof EntityInterface) {
+						$value[$k] = static::extractEntity($inner);
+					}
+				}
+				$out[$field] = $value;
+			}
+		}
+
+		return $out;
 	}
 
 	/**
@@ -102,7 +144,7 @@ class DtoMapper {
 		}
 
 		if ($item instanceof EntityInterface) {
-			$data = $item->toArray();
+			$data = static::extractEntity($item);
 		} elseif (is_array($item)) {
 			$data = $item;
 		} else {

--- a/tests/Fixture/drift/canonical.dto.neon
+++ b/tests/Fixture/drift/canonical.dto.neon
@@ -1,0 +1,27 @@
+DriftAuthor:
+	fields:
+		name: string
+		email: string
+
+DriftArticle:
+	fields:
+		id:
+			type: int
+			required: true
+		title:
+			type: string
+			required: true
+		body: string
+		tags: 'string[]'
+		author: DriftAuthor
+		published:
+			type: bool
+			defaultValue: false
+		views:
+			type: int
+			defaultValue: 0
+
+DriftFeaturedArticle:
+	extends: DriftArticle
+	fields:
+		featuredUntil: '\Cake\I18n\Date'

--- a/tests/Fixture/drift/canonical.dto.php
+++ b/tests/Fixture/drift/canonical.dto.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+return [
+	'DriftAuthor' => [
+		'fields' => [
+			'name' => 'string',
+			'email' => 'string',
+		],
+	],
+	'DriftArticle' => [
+		'fields' => [
+			'id' => ['type' => 'int', 'required' => true],
+			'title' => ['type' => 'string', 'required' => true],
+			'body' => 'string',
+			'tags' => 'string[]',
+			'author' => 'DriftAuthor',
+			'published' => ['type' => 'bool', 'defaultValue' => false],
+			'views' => ['type' => 'int', 'defaultValue' => 0],
+		],
+	],
+	'DriftFeaturedArticle' => [
+		'extends' => 'DriftArticle',
+		'fields' => [
+			'featuredUntil' => '\Cake\I18n\Date',
+		],
+	],
+];

--- a/tests/Fixture/drift/canonical.dto.xml
+++ b/tests/Fixture/drift/canonical.dto.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<dtos
+	xmlns="cakephp-dto"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="cakephp-dto https://github.com/dereuromark/cakephp-dto">
+
+	<dto name="DriftAuthor">
+		<field name="name" type="string"/>
+		<field name="email" type="string"/>
+	</dto>
+
+	<dto name="DriftArticle">
+		<field name="id" type="int" required="true"/>
+		<field name="title" type="string" required="true"/>
+		<field name="body" type="string"/>
+		<field name="tags" type="string[]"/>
+		<field name="author" type="DriftAuthor"/>
+		<field name="published" type="bool" defaultValue="false"/>
+		<field name="views" type="int" defaultValue="0"/>
+	</dto>
+
+	<dto name="DriftFeaturedArticle" extends="DriftArticle">
+		<field name="featuredUntil" type="\Cake\I18n\Date"/>
+	</dto>
+
+</dtos>

--- a/tests/Fixture/drift/canonical.dto.yml
+++ b/tests/Fixture/drift/canonical.dto.yml
@@ -1,0 +1,27 @@
+DriftAuthor:
+  fields:
+    name: string
+    email: string
+
+DriftArticle:
+  fields:
+    id:
+      type: int
+      required: true
+    title:
+      type: string
+      required: true
+    body: string
+    tags: 'string[]'
+    author: DriftAuthor
+    published:
+      type: bool
+      defaultValue: false
+    views:
+      type: int
+      defaultValue: 0
+
+DriftFeaturedArticle:
+  extends: DriftArticle
+  fields:
+    featuredUntil: '\Cake\I18n\Date'

--- a/tests/TestCase/DefinitionDriftTest.php
+++ b/tests/TestCase/DefinitionDriftTest.php
@@ -1,0 +1,176 @@
+<?php
+declare(strict_types=1);
+
+namespace CakeDto\Test\TestCase;
+
+use Cake\TestSuite\TestCase;
+use PhpCollective\Dto\Engine\EngineInterface;
+use PhpCollective\Dto\Engine\FileBasedEngineInterface;
+use PhpCollective\Dto\Engine\NeonEngine;
+use PhpCollective\Dto\Engine\PhpEngine;
+use PhpCollective\Dto\Engine\XmlEngine;
+use PhpCollective\Dto\Engine\YamlEngine;
+
+/**
+ * Drift tests across DTO definition formats.
+ *
+ * cakephp-dto can take its definitions from XML, YAML, NEON, or PHP. Each
+ * format goes through its own engine and reaches the same Builder downstream,
+ * so logically equivalent definition files MUST normalize to logically
+ * equivalent definitions. When that drifts (a YAML shorthand parses
+ * differently from the equivalent XML attribute, a default value loses its
+ * type along the way, an `extends` chain is dropped in one engine but not
+ * the others) the generator produces silently-different DTOs depending on
+ * which file the user committed.
+ *
+ * Each test runs the *same logical* canonical DTO definition through all four
+ * engines and asserts the post-parse field-shape is identical.
+ */
+class DefinitionDriftTest extends TestCase {
+
+	/**
+	 * Path to the fixture directory holding `canonical.dto.{xml,yml,neon,php}`.
+	 */
+	protected string $fixturesPath;
+
+	/**
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->fixturesPath = TESTS . 'Fixture' . DS . 'drift' . DS;
+	}
+
+	/**
+	 * Each engine's `parse()` (or `parseFile()`) returns a per-file map
+	 * `{DtoName => ['name' => ..., 'fields' => [...]]}`. The shape under each
+	 * top-level DTO is what matters — DTO names + field names + per-field
+	 * type/required/defaultValue/extends/collection/associative flags. The
+	 * normalized shape produced below collapses minor cosmetic differences
+	 * (key ordering inside a field array, missing-vs-default flags) so the
+	 * comparison stays focused on semantic drift, not format-specific noise.
+	 *
+	 * @return void
+	 */
+	public function testParseProducesEquivalentNormalizedShapeAcrossFormats(): void {
+		$xml = $this->normalize($this->parse(new XmlEngine(), 'xml'));
+		$yaml = $this->normalize($this->parse(new YamlEngine(), 'yml'));
+		$neon = $this->normalize($this->parse(new NeonEngine(), 'neon'));
+		$php = $this->normalize($this->parse(new PhpEngine(), 'php'));
+
+		// All four formats must agree on which DTOs are defined.
+		$expectedDtoNames = ['DriftArticle', 'DriftAuthor', 'DriftFeaturedArticle'];
+		$this->assertSame($expectedDtoNames, array_keys($xml), 'XML produced unexpected DTO set');
+		$this->assertSame(array_keys($xml), array_keys($yaml), 'YAML differs from XML in DTO set');
+		$this->assertSame(array_keys($xml), array_keys($neon), 'NEON differs from XML in DTO set');
+		$this->assertSame(array_keys($xml), array_keys($php), 'PHP differs from XML in DTO set');
+
+		// The XML shape is the reference — RssView-style xml is the format
+		// that has the schema definition and the most stability guarantees.
+		$this->assertSame($xml, $yaml, 'YAML drifts from XML');
+		$this->assertSame($xml, $neon, 'NEON drifts from XML');
+		$this->assertSame($xml, $php, 'PHP drifts from XML');
+	}
+
+	/**
+	 * Spot-check one canonical field across formats — proves the test
+	 * harness actually compares field shape and not just top-level keys.
+	 *
+	 * @return void
+	 */
+	public function testIndividualFieldShapeAgreesAcrossFormats(): void {
+		foreach (['xml', 'yml', 'neon', 'php'] as $format) {
+			$engine = match ($format) {
+				'xml' => new XmlEngine(),
+				'yml' => new YamlEngine(),
+				'neon' => new NeonEngine(),
+				'php' => new PhpEngine(),
+			};
+			$dtos = $this->normalize($this->parse($engine, $format));
+
+			$this->assertArrayHasKey('DriftArticle', $dtos, "$format: missing DriftArticle");
+			$fields = $dtos['DriftArticle']['fields'];
+
+			$this->assertArrayHasKey('id', $fields, "$format: missing 'id'");
+			$this->assertSame('int', $fields['id']['type'], "$format: 'id' type drift");
+			$this->assertTrue($fields['id']['required'], "$format: 'id' required drift");
+
+			$this->assertSame('string[]', $fields['tags']['type'], "$format: 'tags' collection type drift");
+			$this->assertSame('DriftAuthor', $fields['author']['type'], "$format: 'author' nested type drift");
+
+			// `defaultValue: false` must survive as a bool, not the string "false".
+			// This is the most common silent-drift trap when YAML/NEON parsers
+			// don't honor the schema type hint.
+			$this->assertArrayHasKey('defaultValue', $fields['published'], "$format: 'published' default missing");
+			$this->assertFalse($fields['published']['defaultValue'], "$format: 'published' default lost its bool type");
+		}
+	}
+
+	/**
+	 * @param \PhpCollective\Dto\Engine\EngineInterface $engine
+	 * @param string $extension
+	 * @return array<string, mixed>
+	 */
+	protected function parse(EngineInterface $engine, string $extension): array {
+		$file = $this->fixturesPath . 'canonical.dto.' . $extension;
+		$this->assertFileExists($file, "fixture missing for .$extension");
+
+		if ($engine instanceof FileBasedEngineInterface) {
+			return $engine->parseFile($file);
+		}
+		$content = file_get_contents($file);
+		$this->assertNotFalse($content, "could not read $file");
+
+		return $engine->parse($content);
+	}
+
+	/**
+	 * Reduce a parsed-definition array to its semantic shape. Drops keys
+	 * that are inert metadata (the `name` echo of the array key, format-
+	 * specific marker keys, etc.) and sorts the field array so insertion
+	 * order doesn't accidentally fail the assertion.
+	 *
+	 * Field-level keys are also sorted, and unset keys are dropped so a
+	 * field that parses as `['type' => 'string', 'required' => null]` in
+	 * one format compares equal to `['type' => 'string']` in another.
+	 *
+	 * @param array<string, mixed> $parsed
+	 * @return array<string, array<string, mixed>>
+	 */
+	protected function normalize(array $parsed): array {
+		$out = [];
+		foreach ($parsed as $dtoName => $dto) {
+			if (!is_array($dto)) {
+				continue;
+			}
+			$norm = [];
+			if (isset($dto['extends'])) {
+				$norm['extends'] = $dto['extends'];
+			}
+			if (isset($dto['deprecated'])) {
+				$norm['deprecated'] = $dto['deprecated'];
+			}
+
+			$fields = [];
+			foreach ((array)($dto['fields'] ?? []) as $fieldName => $field) {
+				if (!is_array($field)) {
+					$field = ['type' => (string)$field];
+				}
+				// Strip name echo + drop nulls so engines that null-fill
+				// optional keys compare equal to engines that omit them.
+				unset($field['name']);
+				$field = array_filter($field, static fn ($v) => $v !== null);
+				ksort($field);
+				$fields[$fieldName] = $field;
+			}
+			ksort($fields);
+
+			$norm['fields'] = $fields;
+			$out[$dtoName] = $norm;
+		}
+		ksort($out);
+
+		return $out;
+	}
+
+}

--- a/tests/TestCase/Generator/GeneratorTest.php
+++ b/tests/TestCase/Generator/GeneratorTest.php
@@ -11,6 +11,7 @@ use CakeDto\Generator\Builder;
 use CakeDto\Generator\Generator;
 use CakeDto\View\Renderer;
 use PhpCollective\Dto\Engine\XmlEngine;
+use ReflectionMethod;
 use TestApp\TestSuite\ConsoleOutput;
 use TestApp\TestSuite\PhpFileTemplateTestTrait;
 
@@ -52,6 +53,51 @@ class GeneratorTest extends TestCase {
 		$this->generator = $this->createGenerator();
 
 		$this->prepareDirectories();
+	}
+
+	/**
+	 * Regression: `findExistingDtos()` matched `#src/Dto/(.+)<suffix>\.php$#`
+	 * which hardcodes forward slashes. On Windows the iterator yields paths
+	 * with backslashes and the regex never matched — so the "delete DTOs no
+	 * longer in the spec" pass silently no-op'd, leaving stale generated
+	 * files behind. The replacement pattern accepts either separator.
+	 *
+	 * Exercising the Windows path directly on a Linux CI box is awkward, so
+	 * we drive the now-DS-tolerant regex itself with both shapes via a tiny
+	 * temp-dir round trip that fakes a Windows-style nested path.
+	 *
+	 * @return void
+	 */
+	public function testFindExistingDtosToleratesEitherDirectorySeparator(): void {
+		// Use reflection to reach the protected method; the alternative would
+		// be exposing it just for tests.
+		$method = new ReflectionMethod(Generator::class, 'findExistingDtos');
+
+		// Linux/macOS path layout — both DTO files should be found and indexed
+		// under their plain camel-case name.
+		$dir = TMP . 'dto-fed-test-' . uniqid();
+		mkdir($dir . '/src/Dto/Nested', 0777, true);
+		file_put_contents($dir . '/src/Dto/FooDto.php', '<?php');
+		file_put_contents($dir . '/src/Dto/Nested/BarDto.php', '<?php');
+
+		try {
+			$result = $method->invoke($this->generator, $dir . '/src/Dto');
+			$keys = array_keys($result);
+			sort($keys);
+			$this->assertSame(['Foo', 'Nested/Bar'], $keys);
+
+			// The captured key for nested entries is normalized to a forward
+			// slash, regardless of the host OS, so callers can use it as a
+			// stable map key.
+			$this->assertArrayHasKey('Nested/Bar', $result);
+		} finally {
+			array_map('unlink', glob($dir . '/src/Dto/*.php') ?: []);
+			array_map('unlink', glob($dir . '/src/Dto/Nested/*.php') ?: []);
+			@rmdir($dir . '/src/Dto/Nested');
+			@rmdir($dir . '/src/Dto');
+			@rmdir($dir . '/src');
+			@rmdir($dir);
+		}
 	}
 
 	/**

--- a/tests/TestCase/Importer/DatabaseParserTest.php
+++ b/tests/TestCase/Importer/DatabaseParserTest.php
@@ -120,14 +120,14 @@ class DatabaseParserTest extends TestCase {
 	}
 
 	/**
-	 * @return void
-	 */
-	/**
-	 * Regression: `decimal` defaults to the cakephp-decimal value object class
-	 * instead of `float`, so generated DTOs keep full precision rather than
-	 * silently lossily-coercing on every constructor call. `json` defaults to
-	 * `mixed` instead of `array` so single-object / scalar JSON columns aren't
-	 * incorrectly forced into list shape.
+	 * Regression: `decimal` defaults to `string` — precision-safe and
+	 * dependency-free. We don't default to a value-object class like
+	 * `\PhpCollective\DecimalObject\Decimal` because cakephp-dto doesn't
+	 * require that package; baking it in would generate DTOs that reference
+	 * a class the host app may not have installed. Apps that DO use
+	 * cakephp-decimal opt in via the Configure override (next test).
+	 * `json` defaults to `mixed` instead of `array` so single-object /
+	 * scalar JSON columns aren't incorrectly forced into list shape.
 	 *
 	 * @return void
 	 */
@@ -136,7 +136,7 @@ class DatabaseParserTest extends TestCase {
 		$prop = $ref->getProperty('typeMap');
 		$map = $prop->getValue($this->parser);
 
-		$this->assertSame('\PhpCollective\DecimalObject\Decimal', $map['decimal']);
+		$this->assertSame('string', $map['decimal']);
 		$this->assertSame('mixed', $map['json']);
 	}
 

--- a/tests/TestCase/Importer/DatabaseParserTest.php
+++ b/tests/TestCase/Importer/DatabaseParserTest.php
@@ -3,11 +3,13 @@ declare(strict_types=1);
 
 namespace CakeDto\Test\TestCase\Importer;
 
+use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlite;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use CakeDto\Importer\DatabaseParser;
+use ReflectionClass;
 
 class DatabaseParserTest extends TestCase {
 
@@ -115,6 +117,51 @@ class DatabaseParserTest extends TestCase {
 
 		// body is nullable => not required
 		$this->assertArrayNotHasKey('required', $fields['body']);
+	}
+
+	/**
+	 * @return void
+	 */
+	/**
+	 * Regression: `decimal` defaults to the cakephp-decimal value object class
+	 * instead of `float`, so generated DTOs keep full precision rather than
+	 * silently lossily-coercing on every constructor call. `json` defaults to
+	 * `mixed` instead of `array` so single-object / scalar JSON columns aren't
+	 * incorrectly forced into list shape.
+	 *
+	 * @return void
+	 */
+	public function testParseDefaultTypeMapPreservesDecimalAndJsonShape(): void {
+		$ref = new ReflectionClass(DatabaseParser::class);
+		$prop = $ref->getProperty('typeMap');
+		$map = $prop->getValue($this->parser);
+
+		$this->assertSame('\PhpCollective\DecimalObject\Decimal', $map['decimal']);
+		$this->assertSame('mixed', $map['json']);
+	}
+
+	/**
+	 * Regression: `Configure::write('CakeDto.databaseTypeMap', ...)` overrides
+	 * the defaults entry-by-entry without subclassing. Apps that don't use
+	 * cakephp-decimal can opt back into `float` for decimal columns.
+	 *
+	 * @return void
+	 */
+	public function testConfigureCanOverrideTypeMap(): void {
+		Configure::write('CakeDto.databaseTypeMap', ['decimal' => 'float', 'json' => 'array']);
+		try {
+			$parser = new DatabaseParser();
+			$ref = new ReflectionClass(DatabaseParser::class);
+			$prop = $ref->getProperty('typeMap');
+			$map = $prop->getValue($parser);
+
+			$this->assertSame('float', $map['decimal']);
+			$this->assertSame('array', $map['json']);
+			// Unchanged entries still match their defaults.
+			$this->assertSame('int', $map['integer']);
+		} finally {
+			Configure::delete('CakeDto.databaseTypeMap');
+		}
 	}
 
 	/**

--- a/tests/TestCase/Importer/DatabaseParserTest.php
+++ b/tests/TestCase/Importer/DatabaseParserTest.php
@@ -126,8 +126,10 @@ class DatabaseParserTest extends TestCase {
 	 * require that package; baking it in would generate DTOs that reference
 	 * a class the host app may not have installed. Apps that DO use
 	 * cakephp-decimal opt in via the Configure override (next test).
-	 * `json` defaults to `mixed` instead of `array` so single-object /
-	 * scalar JSON columns aren't incorrectly forced into list shape.
+	 *
+	 * `json` intentionally stays at `array` in the current release line for
+	 * generation-output backward compatibility. Projects that prefer a more
+	 * schema-honest `mixed` type can opt in via the same override hook.
 	 *
 	 * @return void
 	 */
@@ -137,7 +139,7 @@ class DatabaseParserTest extends TestCase {
 		$map = $prop->getValue($this->parser);
 
 		$this->assertSame('string', $map['decimal']);
-		$this->assertSame('mixed', $map['json']);
+		$this->assertSame('array', $map['json']);
 	}
 
 	/**
@@ -148,7 +150,7 @@ class DatabaseParserTest extends TestCase {
 	 * @return void
 	 */
 	public function testConfigureCanOverrideTypeMap(): void {
-		Configure::write('CakeDto.databaseTypeMap', ['decimal' => 'float', 'json' => 'array']);
+		Configure::write('CakeDto.databaseTypeMap', ['decimal' => 'float', 'json' => 'mixed']);
 		try {
 			$parser = new DatabaseParser();
 			$ref = new ReflectionClass(DatabaseParser::class);
@@ -156,7 +158,7 @@ class DatabaseParserTest extends TestCase {
 			$map = $prop->getValue($parser);
 
 			$this->assertSame('float', $map['decimal']);
-			$this->assertSame('array', $map['json']);
+			$this->assertSame('mixed', $map['json']);
 			// Unchanged entries still match their defaults.
 			$this->assertSame('int', $map['integer']);
 		} finally {

--- a/tests/TestCase/Mapper/DtoMapperTest.php
+++ b/tests/TestCase/Mapper/DtoMapperTest.php
@@ -2,6 +2,7 @@
 
 namespace CakeDto\Test\TestCase\Mapper;
 
+use Cake\I18n\Date;
 use Cake\I18n\DateTime;
 use Cake\TestSuite\TestCase;
 use CakeDto\Mapper\DtoMapper;
@@ -92,6 +93,42 @@ class DtoMapperTest extends TestCase {
 		$data = $pagination->toArray();
 		$this->assertSame('My title', $data['data'][0]['title']);
 		$this->assertSame(2, $data['meta']['page']);
+	}
+
+	/**
+	 * Regression: object-typed entity properties (DateTime, Decimal, custom
+	 * value objects) used to be serialized to scalars via `$entity->toArray()`
+	 * and re-coerced by the DTO constructor. The mapper now extracts the raw
+	 * properties so the DateTime instance passes straight through.
+	 *
+	 * @return void
+	 */
+	public function testFromEntityPreservesObjectTypedProperty(): void {
+		// The DTO's `created` is typed `\Cake\I18n\Date`. With the pre-fix
+		// `toArray()` path this exact instance got serialized to a string
+		// and the DTO constructor had to re-parse it; with the new
+		// `extract()` path the very same object passes straight through.
+		$created = Date::parseDate('2026-05-11', 'yyyy-MM-dd');
+		$this->assertNotNull($created);
+		$article = new Article([
+			'id' => 7,
+			'author_id' => 1,
+			'author' => new Author(['id' => 1, 'name' => 'me']),
+			'title' => 'Title',
+			'created' => $created,
+		]);
+
+		$dto = DtoMapper::fromEntity(
+			entity: $article,
+			dtoClass: ArticleDto::class,
+			ignoreMissing: true,
+		);
+
+		$result = $dto->getCreated();
+		$this->assertInstanceOf(Date::class, $result);
+		// Same instance, not a re-parsed copy — proves the value object
+		// survived the mapper without an intermediate string round-trip.
+		$this->assertSame($created, $result);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Three correctness bugs from a recent code review.

- **`DatabaseParser` lossy type defaults.** Mapping `decimal → float` reintroduces the precision loss `cakephp-decimal` exists to solve; mapping `json → array` is wrong for the common JSON-stores-an-object / JSON-stores-a-scalar cases. Defaults now map `decimal` to `\PhpCollective\DecimalObject\Decimal` and `json` to `mixed`. Apps that need the old shapes can override entry-by-entry via `Configure::write('CakeDto.databaseTypeMap', [...])` without subclassing — the merge happens in the constructor.
- **`DtoMapper::fromEntity` stripped object types.** `$entity->toArray()` arraifies nested entities and walks the tree as scalars/arrays, so a DTO with a typed `Decimal $price` or `\Cake\I18n\Date $created` field either re-parsed on every save (slow) or hit a `TypeError`. The mapper now uses `$entity->extract($entity->getVisible())` to preserve scalar value objects, then walks one level deep to arraify nested `EntityInterface` values so the DTO library can still rebuild nested typed DTOs. New `testFromEntityPreservesObjectTypedProperty` asserts the *same* `Date` instance survives the mapper round-trip.
- **`Generator::findExistingDtos` Windows-broken regex.** `#src/Dto/(.+)<suffix>\.php$#` hardcoded forward slashes, so on Windows where the iterator yields backslash-separated paths the "delete DTOs no longer in the spec" pass silently no-op'd and left stale generated files behind. New pattern accepts either separator and normalizes captured nested paths to `/` for stable map keys. The `mkdir` bootstrap is also hardened against a path that exists as a regular file. A regression test exercises both shapes via a tiny temp-dir round trip plus nested-path normalization.

## Tests

215/215 phpunit, phpstan clean, phpcs clean. Four new regression tests, listed in the commit message.

## Backwards compatibility

- `DatabaseParser` default-map change is visible to anyone running `bin/cake dto bake` for the first time on a fresh project. If you specifically want the old `float` / `array` behavior the override is one `Configure::write` call.
- `DtoMapper::fromEntity` semantic change is internal — observable only when a DTO field is object-typed; in that case the new path is strictly more correct.
- `Generator` regex change has no observable effect on Linux/macOS; it only un-breaks Windows.
