### PR TITLE
Silence PHPUnit mock-without-expectations notices

### DIFF
--- a/tests/TestCase/Command/DtoGenerateCommandTest.php
+++ b/tests/TestCase/Command/DtoGenerateCommandTest.php
@@ -7,8 +7,10 @@ use Cake\Console\ConsoleIo;
 use Cake\TestSuite\TestCase;
 use CakeDto\Command\DtoGenerateCommand;
 use CakeDto\Filesystem\Folder;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use TestApp\TestSuite\ConsoleOutput;
 
+#[AllowMockObjectsWithoutExpectations]
 class DtoGenerateCommandTest extends TestCase {
 
 	/**

--- a/tests/TestCase/Command/DtoInitCommandTest.php
+++ b/tests/TestCase/Command/DtoInitCommandTest.php
@@ -8,8 +8,10 @@ use Cake\Console\Exception\StopException;
 use Cake\TestSuite\TestCase;
 use CakeDto\Command\DtoInitCommand;
 use CakeDto\Filesystem\Folder;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use TestApp\TestSuite\ConsoleOutput;
 
+#[AllowMockObjectsWithoutExpectations]
 class DtoInitCommandTest extends TestCase {
 
 	/**

--- a/tests/TestCase/Dto/GithubTest.php
+++ b/tests/TestCase/Dto/GithubTest.php
@@ -7,9 +7,11 @@ use Cake\Console\ConsoleIo;
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use CakeDto\Command\DtoGenerateCommand;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Sandbox\Dto\Github\PullRequestDto;
 use TestApp\TestSuite\ConsoleOutput;
 
+#[AllowMockObjectsWithoutExpectations]
 class GithubTest extends TestCase {
 
 	/**

--- a/tests/TestCase/Generator/BuilderTest.php
+++ b/tests/TestCase/Generator/BuilderTest.php
@@ -9,11 +9,13 @@ use CakeDto\Generator\Builder;
 use InvalidArgumentException;
 use PhpCollective\Dto\Engine\EngineInterface;
 use PhpCollective\Dto\Engine\XmlEngine;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use TestApp\Dto\AuthorDto;
 use TestApp\Dto\CarDto;
 use TestApp\DtoCustom\DummyNonDtoClass;
 use TestApp\TestSuite\AssociativeArrayTestTrait;
 
+#[AllowMockObjectsWithoutExpectations]
 class BuilderTest extends TestCase {
 
 	use AssociativeArrayTestTrait;
@@ -1294,7 +1296,7 @@ class BuilderTest extends TestCase {
 	 * @return \CakeDto\Generator\Builder|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected function createBuilder(): Builder {
-		$engine = $this->getMockBuilder(EngineInterface::class)->getMock();
+		$engine = $this->createStub(EngineInterface::class);
 		$builder = $this->getMockBuilder(Builder::class)->onlyMethods(['mergeConfigs', 'getFiles'])->setConstructorArgs([$engine])->getMock();
 		$builder->method('getFiles')->willReturn([]);
 


### PR DESCRIPTION
## Summary

PHPUnit 11+ emits a notice ("No expectations were configured for the mock object") whenever a `MockObject` is created without any `expects(...)` call. The plugin's test suite was producing 20 of these — they don't affect pass/fail but pollute the output.

The shape of the affected tests is correct: four files use partial mocks (`getMockBuilder(...)->onlyMethods([...])`) purely as stubs, configuring return values via `->method(...)->willReturn(...)` without expectations. That's the right primitive for these tests.

## Fix

- Mark the affected classes with PHPUnit's canonical opt-out attribute, `#[AllowMockObjectsWithoutExpectations]`:
  - `tests/TestCase/Command/DtoGenerateCommandTest.php`
  - `tests/TestCase/Command/DtoInitCommandTest.php`
  - `tests/TestCase/Dto/GithubTest.php`
  - `tests/TestCase/Generator/BuilderTest.php`
- Convert the `EngineInterface` mock in `BuilderTest::createBuilder()` from `getMockBuilder(...)->getMock()` to `createStub(...)` — it has no partial-mock needs (no `onlyMethods`, no configured methods), so a `Stub` is the right shape and avoids the notice without needing the attribute on its account.

## Result

PHPUnit output goes from `Tests: 217, Assertions: 813, PHPUnit Notices: 20` to `OK (217 tests, 813 assertions)`. PHPStan and PHPCS unchanged (clean).