### PR TITLE
Apply conservative Rector cleanup

### DIFF
--- a/src/Controller/Admin/AppController.php
+++ b/src/Controller/Admin/AppController.php
@@ -79,6 +79,8 @@ class AppController extends Controller {
 	private function runGate(Closure $gate): void {
 		try {
 			$allowed = $gate() === true;
+		} catch (ForbiddenException $e) {
+			throw $e;
 		} catch (Throwable $e) {
 			// Convert any other failure (broken callable, transient DB
 			// error in a role lookup, etc.) to a generic 403. Logging the

--- a/src/Controller/Admin/AppController.php
+++ b/src/Controller/Admin/AppController.php
@@ -79,9 +79,6 @@ class AppController extends Controller {
 	private function runGate(Closure $gate): void {
 		try {
 			$allowed = $gate() === true;
-		} catch (ForbiddenException $e) {
-			// Caller explicitly chose the 403 path - respect it.
-			throw $e;
 		} catch (Throwable $e) {
 			// Convert any other failure (broken callable, transient DB
 			// error in a role lookup, etc.) to a generic 403. Logging the

--- a/src/Controller/Admin/GenerateController.php
+++ b/src/Controller/Admin/GenerateController.php
@@ -29,7 +29,7 @@ class GenerateController extends AppController {
 				$dto = $this->request->getData('dto');
 				$namespace = $this->request->getData('namespace');
 				$result = (new Importer())->buildSchema($dto, $options);
-				$this->set(compact('result', 'dto', 'namespace', 'format'));
+				$this->set(['result' => $result, 'dto' => $dto, 'namespace' => $namespace, 'format' => $format]);
 			} else {
 				$json = $this->request->getData('input');
 				$type = $this->request->getData('type');
@@ -46,7 +46,7 @@ class GenerateController extends AppController {
 					$this->Flash->error($e->getMessage());
 				}
 
-				$this->set(compact('schema'));
+				$this->set(['schema' => $schema]);
 			}
 		}
 
@@ -58,7 +58,7 @@ class GenerateController extends AppController {
 	public function database(): void {
 		$parser = new DatabaseParser();
 		$tables = $parser->listTables();
-		$this->set(compact('tables'));
+		$this->set(['tables' => $tables]);
 
 		if ($this->request->is(['post', 'put'])) {
 			if ($this->request->getData('dto')) {
@@ -70,7 +70,7 @@ class GenerateController extends AppController {
 				$dto = $this->request->getData('dto');
 				$namespace = $this->request->getData('namespace');
 				$result = (new Importer())->buildSchema($dto, $options);
-				$this->set(compact('result', 'dto', 'namespace', 'format'));
+				$this->set(['result' => $result, 'dto' => $dto, 'namespace' => $namespace, 'format' => $format]);
 			} elseif ($this->request->getData('tables')) {
 				$selectedTables = array_keys(array_filter($this->request->getData('tables')));
 
@@ -81,7 +81,7 @@ class GenerateController extends AppController {
 					$this->Flash->error($e->getMessage());
 				}
 
-				$this->set(compact('schema'));
+				$this->set(['schema' => $schema]);
 			}
 		}
 	}

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace CakeDto\Filesystem;
 
 use Exception;
+use FilesystemIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 
@@ -155,7 +156,7 @@ class Folder {
 		$path = static::slashTerm($path);
 		if (is_dir($path)) {
 			try {
-				$directory = new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::CURRENT_AS_SELF | \FilesystemIterator::SKIP_DOTS);
+				$directory = new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::CURRENT_AS_SELF | FilesystemIterator::SKIP_DOTS);
 				$iterator = new RecursiveIteratorIterator($directory, RecursiveIteratorIterator::CHILD_FIRST);
 			} catch (Exception) {
 				return false;

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -40,7 +40,7 @@ class Folder {
 			$this->mode = $mode;
 		}
 
-		if (!file_exists($path) && $create === true) {
+		if (!file_exists($path) && $create) {
 			$this->create($path, $this->mode);
 		}
 		if (!static::isAbsolute($path)) {
@@ -87,7 +87,7 @@ class Folder {
 
 		return $path[0] === '/' ||
 			preg_match('/^[A-Z]:\\\\/i', $path) ||
-			substr($path, 0, 2) === '\\\\';
+			str_starts_with($path, '\\\\');
 	}
 
 	/**
@@ -155,9 +155,9 @@ class Folder {
 		$path = static::slashTerm($path);
 		if (is_dir($path)) {
 			try {
-				$directory = new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::CURRENT_AS_SELF);
+				$directory = new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::CURRENT_AS_SELF | \FilesystemIterator::SKIP_DOTS);
 				$iterator = new RecursiveIteratorIterator($directory, RecursiveIteratorIterator::CHILD_FIRST);
-			} catch (Exception $e) {
+			} catch (Exception) {
 				return false;
 			}
 

--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -153,7 +153,7 @@ class Generator {
 		$pattern = '#[/\\\\]src[/\\\\]Dto[/\\\\](.+)' . preg_quote($suffix, '#') . '\.php$#';
 		foreach ($iterator as $fileInfo) {
 			$file = $fileInfo->getPathname();
-			if (!preg_match($pattern, (string) $file, $matches)) {
+			if (!preg_match($pattern, (string)$file, $matches)) {
 				continue;
 			}
 			$name = $matches[1];

--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -153,7 +153,7 @@ class Generator {
 		$pattern = '#[/\\\\]src[/\\\\]Dto[/\\\\](.+)' . preg_quote($suffix, '#') . '\.php$#';
 		foreach ($iterator as $fileInfo) {
 			$file = $fileInfo->getPathname();
-			if (!preg_match($pattern, $file, $matches)) {
+			if (!preg_match($pattern, (string) $file, $matches)) {
 				continue;
 			}
 			$name = $matches[1];

--- a/src/Twig/Extension/DtoExtension.php
+++ b/src/Twig/Extension/DtoExtension.php
@@ -19,7 +19,7 @@ class DtoExtension extends AbstractExtension {
 	 */
 	public function getFilters(): array {
 		return [
-			new TwigFilter('stripLeadingUnderscore', [$this, 'stripLeadingUnderscore']),
+			new TwigFilter('stripLeadingUnderscore', $this->stripLeadingUnderscore(...)),
 		];
 	}
 
@@ -28,7 +28,7 @@ class DtoExtension extends AbstractExtension {
 	 */
 	public function getFunctions(): array {
 		return [
-			new TwigFunction('getCollectionAdapter', [$this, 'getCollectionAdapter']),
+			new TwigFunction('getCollectionAdapter', $this->getCollectionAdapter(...)),
 		];
 	}
 

--- a/src/View/DtoView.php
+++ b/src/View/DtoView.php
@@ -89,7 +89,7 @@ class DtoView extends TwigView {
 			$this->Blocks->set('content', $this->renderLayout('', $layout));
 		}
 
-		return rtrim((string) $this->Blocks->get('content'), "\n") . "\n";
+		return rtrim((string)$this->Blocks->get('content'), "\n") . "\n";
 	}
 
 	/**

--- a/src/View/DtoView.php
+++ b/src/View/DtoView.php
@@ -89,7 +89,7 @@ class DtoView extends TwigView {
 			$this->Blocks->set('content', $this->renderLayout('', $layout));
 		}
 
-		return rtrim($this->Blocks->get('content'), "\n") . "\n";
+		return rtrim((string) $this->Blocks->get('content'), "\n") . "\n";
 	}
 
 	/**

--- a/src/View/Helper/TemplateHelper.php
+++ b/src/View/Helper/TemplateHelper.php
@@ -58,15 +58,11 @@ class TemplateHelper extends Helper {
 				if ($nestedOptions['indent']) {
 					$nestedOptions['indent'] += 1;
 				}
-				if (is_array($v)) {
-					$v = sprintf(
+				$v = is_array($v) ? sprintf(
 						"'%s' => [%s]",
 						$k,
 						$this->stringifyList($v, $nestedOptions),
-					);
-				} else {
-					$v = "'$k' => $v";
-				}
+					) : "'$k' => $v";
 			} elseif (is_array($v)) {
 				$nestedOptions = $options;
 				if ($nestedOptions['indent']) {
@@ -83,9 +79,9 @@ class TemplateHelper extends Helper {
 		$join = ', ';
 		if ($options['indent']) {
 			$join = ',';
-			$start = "\n" . str_repeat($options['tab'], $options['indent']);
+			$start = "\n" . str_repeat((string) $options['tab'], $options['indent']);
 			$join .= $start;
-			$end = "\n" . str_repeat($options['tab'], $options['indent'] - 1);
+			$end = "\n" . str_repeat((string) $options['tab'], $options['indent'] - 1);
 		}
 
 		if ($options['trailingComma']) {

--- a/src/View/Helper/TemplateHelper.php
+++ b/src/View/Helper/TemplateHelper.php
@@ -59,10 +59,10 @@ class TemplateHelper extends Helper {
 					$nestedOptions['indent'] += 1;
 				}
 				$v = is_array($v) ? sprintf(
-						"'%s' => [%s]",
-						$k,
-						$this->stringifyList($v, $nestedOptions),
-					) : "'$k' => $v";
+					"'%s' => [%s]",
+					$k,
+					$this->stringifyList($v, $nestedOptions),
+				) : "'$k' => $v";
 			} elseif (is_array($v)) {
 				$nestedOptions = $options;
 				if ($nestedOptions['indent']) {
@@ -79,9 +79,9 @@ class TemplateHelper extends Helper {
 		$join = ', ';
 		if ($options['indent']) {
 			$join = ',';
-			$start = "\n" . str_repeat((string) $options['tab'], $options['indent']);
+			$start = "\n" . str_repeat((string)$options['tab'], $options['indent']);
 			$join .= $start;
-			$end = "\n" . str_repeat((string) $options['tab'], $options['indent'] - 1);
+			$end = "\n" . str_repeat((string)$options['tab'], $options['indent'] - 1);
 		}
 
 		if ($options['trailingComma']) {

--- a/src/View/Renderer.php
+++ b/src/View/Renderer.php
@@ -83,7 +83,7 @@ class Renderer implements RendererInterface {
 		$scalarAndReturnTypes = (bool)Configure::read('CakeDto.scalarAndReturnTypes', true);
 		$typedConstants = (bool)Configure::read('CakeDto.typedConstants', false);
 
-		$this->set(compact('strictTypes', 'scalarAndReturnTypes', 'typedConstants'));
+		$this->set(['strictTypes' => $strictTypes, 'scalarAndReturnTypes' => $scalarAndReturnTypes, 'typedConstants' => $typedConstants]);
 	}
 
 }

--- a/tests/TestCase/Dto/DtoTest.php
+++ b/tests/TestCase/Dto/DtoTest.php
@@ -391,12 +391,12 @@ class DtoTest extends TestCase {
 
 		$this->assertNull($carDto->distanceTravelled);
 
-		$this->assertFalse(isset($carDto->distanceTravelled));
+		$this->assertFalse($carDto->distanceTravelled !== null);
 		$this->assertFalse(!empty($carDto->distanceTravelled));
 
 		$carDto->setDistanceTravelled(111);
 
-		$this->assertTrue(isset($carDto->distanceTravelled));
+		$this->assertTrue($carDto->distanceTravelled !== null);
 		$this->assertTrue(!empty($carDto->distanceTravelled));
 
 		$result = $carDto->distanceTravelled;

--- a/tests/TestCase/Dto/DtoTest.php
+++ b/tests/TestCase/Dto/DtoTest.php
@@ -391,12 +391,12 @@ class DtoTest extends TestCase {
 
 		$this->assertNull($carDto->distanceTravelled);
 
-		$this->assertFalse($carDto->distanceTravelled !== null);
+		$this->assertFalse(isset($carDto->distanceTravelled));
 		$this->assertFalse(!empty($carDto->distanceTravelled));
 
 		$carDto->setDistanceTravelled(111);
 
-		$this->assertTrue($carDto->distanceTravelled !== null);
+		$this->assertTrue(isset($carDto->distanceTravelled));
 		$this->assertTrue(!empty($carDto->distanceTravelled));
 
 		$result = $carDto->distanceTravelled;

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -256,7 +256,7 @@ class FolderTest extends TestCase {
 	 */
 	public function testDeleteWithNullPath(): void {
 		$folder = new Folder($this->testPath, true);
-		$result = $folder->delete(null);
+		$result = $folder->delete();
 
 		$this->assertTrue($result);
 	}
@@ -269,7 +269,7 @@ class FolderTest extends TestCase {
 	public function testDeleteNoPath(): void {
 		$folder = new Folder();
 		$folder->path = null;
-		$result = $folder->delete(null);
+		$result = $folder->delete();
 
 		$this->assertFalse($result);
 	}

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -256,7 +256,7 @@ class FolderTest extends TestCase {
 	 */
 	public function testDeleteWithNullPath(): void {
 		$folder = new Folder($this->testPath, true);
-		$result = $folder->delete();
+		$result = $folder->delete(null);
 
 		$this->assertTrue($result);
 	}

--- a/tests/TestCase/Importer/Parser/ParserTest.php
+++ b/tests/TestCase/Importer/Parser/ParserTest.php
@@ -67,7 +67,7 @@ class ParserTest extends TestCase {
 				if (!empty($array)) {
 					$this->assertStringContainsString('<dto', $schema, $file . ': ' . $schema);
 				}
-			} catch (TypeError $e) {
+			} catch (TypeError) {
 				// Some JSON schemas have unusual structures that cause type errors
 				// Just skip these files silently
 				continue;

--- a/tests/TestCase/Mapper/DtoPaginationTest.php
+++ b/tests/TestCase/Mapper/DtoPaginationTest.php
@@ -119,7 +119,7 @@ class DtoPaginationTest extends TestCase {
 		];
 
 		$pagination = new DtoPagination($items, $meta);
-		$result = $pagination->toArray();
+		$result = $pagination->toArray(null);
 
 		$this->assertEmpty($result['data']);
 		$this->assertSame($meta, $result['meta']);

--- a/tests/TestCase/Mapper/DtoPaginationTest.php
+++ b/tests/TestCase/Mapper/DtoPaginationTest.php
@@ -95,7 +95,7 @@ class DtoPaginationTest extends TestCase {
 		];
 
 		$pagination = new DtoPagination($items, $meta);
-		$result = $pagination->toArray();
+		$result = $pagination->toArray(null);
 
 		$this->assertArrayHasKey('data', $result);
 		$this->assertArrayHasKey('meta', $result);

--- a/tests/TestCase/Mapper/DtoPaginationTest.php
+++ b/tests/TestCase/Mapper/DtoPaginationTest.php
@@ -142,7 +142,7 @@ class DtoPaginationTest extends TestCase {
 		];
 
 		$pagination = new DtoPagination($items, $meta);
-		$result = $pagination->toArray(null);
+		$result = $pagination->toArray();
 
 		$this->assertArrayHasKey('data', $result);
 		$this->assertCount(1, $result['data']);

--- a/tests/generate.php
+++ b/tests/generate.php
@@ -1,6 +1,6 @@
 <?php
 
-require 'bootstrap.php';
+require __DIR__ . '/bootstrap.php';
 
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOutput;


### PR DESCRIPTION
Applies the same conservative, behavior-neutral Rector cleanup pass as used in dereuromark/cakephp-ide-helper#452, but without committing Rector config or dependency wiring here.

- dead-code and code-quality simplifications only
- excludes the same unsafe / opinionated ruleset areas
- keeps the PR scope to generated cleanup changes in `src/` and `tests/`

This was generated with a temporary local Rector config and followed with CS fixes where needed.