### PR TITLE
Add support for sebastian/diff 9.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
 		"ext-json": "*",
 		"cakephp/cakephp": "^5.1.1",
 		"cakephp/twig-view": "^2.0.1",
-		"sebastian/diff": "^6.0.0 || ^7.0.0 || ^8.0.0",
+		"sebastian/diff": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
 		"php-collective/dto": "^0.1.17"
 	},
 	"require-dev": {

--- a/tests/test_app/src/TestSuite/PhpFileTemplateTestTrait.php
+++ b/tests/test_app/src/TestSuite/PhpFileTemplateTestTrait.php
@@ -5,7 +5,7 @@ namespace TestApp\TestSuite;
 use PHPUnit\Framework\ExpectationFailedException;
 use RuntimeException;
 use SebastianBergmann\Diff\Differ;
-use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
+use SebastianBergmann\Diff\Output\DiffOnlyOutputBuilder;
 
 /**
  * @mixin \Cake\TestSuite\TestCase
@@ -31,7 +31,7 @@ trait PhpFileTemplateTestTrait {
 		try {
 			$this->assertTextContains($needle, $content, $folder . '.' . $template . ' does not match file ' . $file);
 		} catch (ExpectationFailedException $e) {
-			$differ = new Differ(new UnifiedDiffOutputBuilder("\n--- Expected\n+++ Actual\n"));
+			$differ = new Differ(new DiffOnlyOutputBuilder());
 
 			$diff = $differ->diff($needle, $content);
 			$lines = explode("\n", trim($diff));


### PR DESCRIPTION
Adds `sebastian/diff ^9.0.0` to the allowed version range.

The 9.0 release removed `UnifiedDiffOutputBuilder`, so the PhpFileTemplate test trait now uses `DiffOnlyOutputBuilder` instead. This class exists across the 6.x, 7.x, 8.x, and 9.x lines, so the trait stays compatible with all supported versions.

diff 9.x requires PHP 8.4+ and only resolves on the phpunit 13 generation, so this repository's CI matrix continues to exercise diff 8.x. The `^9.0` branch is therefore forward-compatible and was validated against the 9.0.0 API.
