### PR TITLE
Fix PHPStan on CakePHP 5.4

### DIFF
--- a/src/TestSuite/DebugTimer.php
+++ b/src/TestSuite/DebugTimer.php
@@ -101,7 +101,7 @@ class DebugTimer {
 				$name = $_name . ' #' . $i;
 			}
 		}
-		if (!isset(static::$_timers[$name])) {
+		if ($name === null || !isset(static::$_timers[$name])) {
 			return false;
 		}
 		static::$_timers[$name]['end'] = $end;

--- a/src/View/DtoView.php
+++ b/src/View/DtoView.php
@@ -98,7 +98,7 @@ class DtoView extends TwigView {
 	public function dispatchEvent(string $name, array $data = [], ?object $subject = null): EventInterface {
 		$name = preg_replace('/^View\./', 'Dto.', $name) ?? '';
 
-		return parent::dispatchEvent($name, $data, $subject ?? $this);
+		return parent::dispatchEvent($name, $data, $subject);
 	}
 
 	/**


### PR DESCRIPTION
Fixes PHPStan findings surfaced with CakePHP 5.4.0-RC2.\n\nVerified locally with CakePHP 5.4.0-RC2:\n- composer stan\n- composer cs-check\n- composer test